### PR TITLE
feat: batch more github-actions together

### DIFF
--- a/default.json
+++ b/default.json
@@ -38,14 +38,6 @@
   "prConcurrentLimit": 5,
   "packageRules": [
     {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "groupName": "github actions all dependencies",
-      "groupSlug": "github actions all",
-      "minimumReleaseAge": "3 days"
-    },
-    {
       "description": "Py - group boto",
       "groupName": "boto",
       "matchPackagePatterns": [
@@ -152,6 +144,14 @@
       ],
       "groupName": "maven all non-major dependencies",
       "groupSlug": "maven all-minor-patch",
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github actions all dependencies",
+      "groupSlug": "github actions all",
       "minimumReleaseAge": "3 days"
     }
   ],


### PR DESCRIPTION
Reduce noise by grouping github-actions together.  Since the last rule wins on any conflicts this has been moved to the end.

Resolves https://github.com/bcgov/renovate-config/issues/112.