### PR TITLE
feat(ci): group more/all types for action updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -151,9 +151,21 @@
       "matchManagers": [
         "github-actions"
       ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "lockFileMaintenance",
+        "rollback",
+        "bump",
+        "replacement"
+      ],
       "groupName": "github actions all dependencies",
       "groupSlug": "github actions all",
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "1 days"
     }
   ],
   "pre-commit": {


### PR DESCRIPTION
GitHub actions PRs are still coming through in batches for major and minor/patch.  This is an attempt to group all together.