### PR TITLE
chore(ci): set node stability days to 3, like every other package manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -139,7 +139,7 @@
       "matchDatasources": [
         "npm"
       ],
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "3 days"
     },
     {
       "matchManagers": [


### PR DESCRIPTION
All of our package manager types were set to use 3 stability days, except node, with 7.  This fixes that.