### PR TITLE
chore(ci): do not exclude tests and modules

### DIFF
--- a/default.json
+++ b/default.json
@@ -186,6 +186,9 @@
       ]
     }
   ],
+  "ignorePresets": [
+    ":ignoreModulesAndTests"
+  ],
   "pre-commit": {
     "pinDigests": false
   }


### PR DESCRIPTION
Default preset igmoreModulesAndTests has been excluding tests from receiving Renovate updates.  This blocks it.