### PR TITLE
chore: extend minimum release age to 7 days

### DIFF
--- a/default.json
+++ b/default.json
@@ -32,7 +32,7 @@
   "ignorePresets": [
     ":ignoreModulesAndTests"
   ],
-  "minimumReleaseAge": "3 days",
+  "minimumReleaseAge": "7 days",
   "onboarding": true,
   "packageRules": [
     {


### PR DESCRIPTION
A few dependency updates, Java in particular, have hit before their prerequisites were ready.  Moving from 3 to 7 days seems like a reasonable idea.  We can fine tune this later, e.g. varying time for Java, TS/JS, Actions, etc.