### PR TITLE
fix: ignore prereleases

### DIFF
--- a/rules-javascript.json5
+++ b/rules-javascript.json5
@@ -81,7 +81,7 @@
       ]
     },
     {
-      "description": "Ignore prereleases",
+      "description": "Apply prerelease?  False = no.",
       "enabled": false,
       "matchUpdateTypes": [
         "prerelease"

--- a/rules-javascript.json5
+++ b/rules-javascript.json5
@@ -79,6 +79,13 @@
       "matchPackagePatterns": [
         "eslint"
       ]
+    },
+    {
+      "description": "Ignore prereleases",
+      "enabled": false,
+      "matchUpdateTypes": [
+        "prerelease"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Prevent prereleases from being pushed to our repositories.  JavaScript/TypeScript only.