### PR TITLE
chore(ci): exclude bcgov and actions domains from digest pinning

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -69,4 +69,4 @@ jobs:
           node-version: '22'
 
       - name: Validate Config
-        run: npx --yes --package renovate --- "renovate-config-validator --strict default.json renovate.json rules-*.json5"
+        run: npx --yes --package renovate --- "renovate-config-validator default.json renovate.json rules-*.json5"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -69,4 +69,4 @@ jobs:
           node-version: '22'
 
       - name: Validate Config
-        run: npx --yes --package renovate --- "renovate-config-validator --strict default.json renovate.json"
+        run: npx --yes --package renovate --- "renovate-config-validator --strict default.json renovate.json rules-*.json5"

--- a/default.json
+++ b/default.json
@@ -41,5 +41,15 @@
   "platform": "github",
   "platformAutomerge": true,
   "prConcurrentLimit": 2,
-  "pinDigests": true
+  "pinDigests": true,
+  "packageRules": [
+    {
+      "description": "Exclude actions from actions and bcgov domains from pinDigests",
+      "matchPackagePatterns": [
+        "^@actions/",
+        "^@bcgov/"
+      ],
+      "pinDigests": false
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,5 @@
   "description": "Default preset for use with Renovate's repos",
   "extends": [
     "github>bcgov/renovate-config"
-  ],
-  "configMigration": true
+  ]
 }


### PR DESCRIPTION
Exclude bcgov and actions (GitHub official) domains from pinning digests (SHAs).