### PR TITLE
chore: stop pinning official postgres in Actions workflows

### DIFF
--- a/rules-actions.json5
+++ b/rules-actions.json5
@@ -34,6 +34,13 @@
         "/^actions\\//",
         "/^github\\//"
       ]
+    },
+    // Do not pin digests for trusted images in GitHub Actions (e.g., postgres)
+    {
+      "description": "Do not pin digests for trusted images in GitHub Actions (e.g., postgres)",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["/^postgres$/"],
+      "pinDigests": false
     }
     // Add additional rules below as needed
   ]


### PR DESCRIPTION
Prevent pinning of postgres in GitHub Actions.  Here's an example where that isn't beneficial.

```
  java:
    name: Java
    runs-on: ubuntu-24.04
    services:
      postgres:
        image: postgres@sha256:864831322bf2520e7d03d899b01b542de6de9ece6fe29c89f19dc5e1d5568ccf
        env:
          POSTGRES_DB: postgres
          POSTGRES_USER: postgres
          POSTGRES_PASSWORD: postgres
        options: >-
          --health-cmd pg_isready
          --health-interval 10s
          --health-timeout 5s
          --health-retries 5
        ports:
          - 5432:5432
    steps:
      ...
```