### PR TITLE
fix(deps): Use Renovate regex negation syntax to exclude prereleases

### DIFF
--- a/default.json
+++ b/default.json
@@ -48,8 +48,7 @@
     {
       "description": "Block prerelease updates globally (alpha, beta, rc, next, preview, dev, experimental)",
       "groupSlug": "block-prerelease-globally",
-      "enabled": false,
-      "matchCurrentVersion": ".*-(alpha|beta|rc|next|preview|dev|experimental).*"
+      "matchCurrentVersion": "!/.*-(alpha|beta|rc|next|preview|dev|experimental).*/"
     }
   ]
 }


### PR DESCRIPTION
Removed the enabled false flag as it does not appear to be respected

<!-- Provide a general summary of your changes in the Title above -->

# Description

Attempts to enforce the original intent of the rule and fix #210 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Verified on minimal reproduction repo here: https://github.com/jujaga/renovate-37124

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
