### PR TITLE
chore(renovate-config): run Renovate before 6am every weekday

### DIFF
--- a/default.json
+++ b/default.json
@@ -41,6 +41,10 @@
   "onboarding": true,
   "platform": "github",
   "platformAutomerge": true,
+  "timezone": "America/Vancouver",
+  "schedule": [
+    "before 6am every weekday"
+  ],
   "prConcurrentLimit": 2,
   "pinDigests": true,
   "recreateWhen": "never",


### PR DESCRIPTION

## Summary
Batch Renovate activity before work hours to reduce daytime noise.

## Changes
- timezone: America/Vancouver
- schedule: before 6am every weekday

## Impact
- Predictable daily updates with less daytime churn.
