### PR TITLE
feat: add semantic versioning with auto-release workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,62 @@
+name: Merge - Release
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '*.md'
+      - '.github/**'
+      - '.github/graphics/**'
+      - '!.github/workflows/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  semantic-release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Conventional Changelog Update
+        uses: TriPSs/conventional-changelog-action@67139193614f5b9e8db87da1bd4240922b34d765 # v6
+        id: changelog
+        continue-on-error: true
+        with:
+          github-token: ${{ github.token }}
+          output-file: 'CHANGELOG.md'
+          skip-version-file: 'true'
+          skip-commit: 'true'
+          skip-on-empty: 'false'
+          git-push: 'true'
+
+      - name: Create Release
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2
+        if: steps.changelog.outputs.version != ''
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          token: ${{ github.token }}
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          name: ${{ steps.changelog.outputs.tag }}
+          body: |
+            ## Renovate Config Release
+
+            ${{ steps.changelog.outputs.clean_changelog }}
+
+            ### Usage
+            Teams can now use:
+            ```json
+            {
+              "extends": ["github>bcgov/renovate-config#${{ steps.changelog.outputs.tag }}"]
+            }
+            ```

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,4 +1,4 @@
-name: PR Validate
+name: PR - Validate
 
 on:
   pull_request:

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,0 +1,17 @@
+name: PR Validate
+
+on:
+  pull_request:
+    types: [edited, opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-edit-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  validate:
+    name: Validate PR
+    if: (! github.event.pull_request.draft)
+    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-validate.yml@d9b3d32fb3f03c4699c2dce83ddfff042cd31a1f # v1.0.0


### PR DESCRIPTION
## Changes

- **Semantic versioning**: Automatically creates versioned releases based on conventional commits
- **Auto-release on merge**: Creates tags and GitHub releases when changes are merged to main
- **Manual trigger**: Allows immediate releases via workflow dispatch
- **Smart filtering**: Ignores documentation changes to prevent unnecessary releases

## How it works

### Automatic Releases
- **feat: new feature** → minor version bump
- **fix: bug fix** → patch version bump  
- **BREAKING CHANGE:** → major version bump

### Manual Releases
- Use workflow dispatch to force specific version type
- Choose patch, minor, or major version bump

### Team Usage
Teams can now pin to specific versions:


Or use latest main branch:


## Implementation
Based on the proven nr-oracle-service workflow with conventional commit parsing and automatic release creation.

Closes #212