### PR TITLE
fix: prevent service container pinning in GitHub Actions

### DIFF
--- a/default.json
+++ b/default.json
@@ -80,9 +80,6 @@
         "!/^docker\\//",
         "!/^github\\//"
       ],
-      "matchDepTypes": [
-        "action"
-      ],
       "pinDigests": true
     },
     {

--- a/default.json
+++ b/default.json
@@ -55,7 +55,6 @@
       "matchManagers": [
         "docker",
         "docker-compose",
-        "github-actions",
         "gradle",
         "helm",
         "kubernetes",
@@ -68,6 +67,21 @@
         "terraform",
         "uv",
         "yarn"
+      ],
+      "pinDigests": true
+    },
+    {
+      "description": "Pin GitHub Actions (excluding allowlisted orgs and service containers): Pin GitHub Actions for security, but exclude trusted orgs and service containers which are handled separately.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "!/^actions\\//",
+        "!/^docker\\//",
+        "!/^github\\//"
+      ],
+      "matchDepTypes": [
+        "action"
       ],
       "pinDigests": true
     },


### PR DESCRIPTION
## 🚨 URGENT: Fix Service Container Pinning Issue

**Problem:** Renovate is pinning service container digests (like postgres) in GitHub Actions workflows, which we want to prevent.

**Root Cause:** The global pinning rule was overriding the service container unpinning rule.

**Solution:** 
- Removed  from global pinning rule
- Added specific rule to pin GitHub Actions (excluding allowlisted orgs and service containers)
- Added separate rule for allowlisted orgs (actions/, docker/, github/)
- Service container rule now works correctly

**Impact:** This will stop Renovate from creating PRs that pin service container digests in GitHub Actions workflows.

**Example of the problem:** https://github.com/bcgov/quickstart-openshift/pull/2469

This needs to be merged quickly to prevent teams from merging unwanted pinning PRs.