### PR TITLE
feat: suggest upgrading to versioned config

### DIFF
--- a/default.json
+++ b/default.json
@@ -214,6 +214,23 @@
       ],
       "groupName": "ci/cd tools",
       "groupSlug": "cicd"
+    },
+    {
+      "description": "Suggest upgrading to versioned config: Encourage teams using main branch to upgrade to stable v1 version for better stability and automatic updates.",
+      "matchFileNames": [
+        "renovate.json"
+      ],
+      "matchUpdateTypes": [
+        "config"
+      ],
+      "matchCurrentValue": "github>bcgov/renovate-config",
+      "matchNewValue": "github>bcgov/renovate-config#v1",
+      "enabled": true,
+      "automerge": false,
+      "commitMessageAction": "upgrade",
+      "commitMessageTopic": "renovate config",
+      "commitMessageExtra": "to v1",
+      "prBody": "## Upgrade to Versioned Renovate Config\n\nThis PR upgrades your Renovate configuration from the main branch to the stable v1 version.\n\n### Benefits:\n- ✅ **Stable updates** - get tested releases, not development changes\n- ✅ **Automatic upgrades** - get new v1.x.x releases automatically\n- ✅ **No breaking changes** - won't get v2+ breaking changes\n- ✅ **Easy rollback** - can pin to specific version if needed\n\n### What Changes:\n- `github>bcgov/renovate-config` → `github>bcgov/renovate-config#v1`\n\nThis change is recommended for production stability. The v1 version receives regular updates and bug fixes while maintaining backward compatibility."
     }
   ]
 }


### PR DESCRIPTION
## 🎯 Config Version Upgrade Suggestions

**What this does:**
- Suggests teams upgrade from  (main branch) to  (stable version)
- Only targets repos using the main branch - leaves teams with specific versions (v1.0.0, v1.1.0, etc.) alone
- Creates PRs with clear explanation of benefits

**How it works:**
-  - only matches main branch usage
-  - suggests stable v1 version
-  - teams must review and approve the change
- Clear PR body explaining the benefits of versioning

**Benefits for teams:**
- ✅ **Stable updates** - get tested releases, not development changes
- ✅ **Automatic upgrades** - get new v1.x.x releases automatically  
- ✅ **No breaking changes** - won't get v2+ breaking changes
- ✅ **Easy rollback** - can pin to specific version if needed

**Risk assessment:**
- **Low risk** - worst case is nothing happens if Renovate doesn't support config updates
- **Opt-in** - teams can review and decide whether to accept
- **Reversible** - teams can always revert if needed

**Testing:**
This will be tested on main branch first. If it works well, we can promote to stable v1.x.x releases.

Perfect for encouraging teams to adopt versioned configs without manual intervention! 🚀