### PR TITLE
fix: prevent infrastructure pinning (helm, kubernetes, terraform, docker)

### DIFF
--- a/default.json
+++ b/default.json
@@ -54,15 +54,12 @@
       "description": "Global pinning policy: Pin all digests/SHAs globally for supply chain security. This ensures reproducible builds and prevents dependency substitution attacks.",
       "matchManagers": [
         "gradle",
-        "helmv3",
-        "kubernetes",
         "maven",
         "npm",
         "pip",
         "pipenv",
         "pnpm",
         "poetry",
-        "terraform",
         "uv",
         "yarn"
       ],

--- a/default.json
+++ b/default.json
@@ -53,8 +53,6 @@
     {
       "description": "Global pinning policy: Pin all digests/SHAs globally for supply chain security. This ensures reproducible builds and prevents dependency substitution attacks.",
       "matchManagers": [
-        "dockerfile",
-        "docker-compose",
         "gradle",
         "helmv3",
         "kubernetes",


### PR DESCRIPTION
## CRITICAL FIX: Prevent Infrastructure Pinning

### Problem:
Renovate was incorrectly pinning infrastructure components to digests instead of using semantic versioning.

### Root Cause:
Infrastructure managers (helmv3, kubernetes, terraform, dockerfile, docker-compose) were included in the global pinning rule, which overrode the container unpinning rules.

### Fix:
- Removed helmv3, kubernetes, terraform from global pinning rule
- Removed dockerfile, docker-compose from global pinning rule (previous fix)
- Infrastructure now uses semantic versioning (tags) instead of digests
- Language dependencies (npm, pip, gradle, etc.) still get proper digest pinning

### Impact:
- Helm charts use version tags (e.g., v1.2.3)
- Kubernetes manifests use version tags
- Terraform modules use version tags  
- Docker containers use version tags
- Language deps still get digest pinning for security

### Breaking Change:
This is a breaking change for teams using v1.0.0. Infrastructure components will now use version tags instead of digest pins.

Recommendation: Re-release v1.0.0 with this fix or create v1.0.1 as a patch release.

Status: Ready for immediate merge