### PR TITLE
fix: prevent decimal precision changes for renovate-config

### DIFF
--- a/default.json
+++ b/default.json
@@ -210,37 +210,23 @@
       "groupSlug": "cicd"
     },
     {
-      "description": "Prevent patch → minor upgrades for renovate-config: Block teams using patch versions from getting minor updates. This prevents unexpected version type changes.",
+      "description": "Prevent version level changes for renovate-config: Teams must stay at their current version level (patch, minor, or major). This prevents unexpected version level changes.",
       "matchPackageNames": [
         "bcgov/renovate-config"
       ],
       "matchCurrentVersion": "/^v?\\d+\\.0\\.\\d+$/",
       "matchUpdateTypes": [
-        "minor"
-      ],
-      "enabled": false,
-      "automerge": false,
-      "commitMessageAction": "block",
-      "commitMessageTopic": "patch to minor upgrade blocked",
-      "prBody": "## Patch → Minor Upgrade Blocked\n\nThis update was blocked because it would change from patch to minor version.\n\n### Issue:\n- **Current version**: $currentVersion (patch version)\n- **Requested upgrade**: $newVersion (minor version)\n- **Problem**: This would change from patch to minor, which is not allowed.\n\n### Solution:\nTeams using patch versions must stay on patch versions:\n- **Allowed**: v1.0.0 → v1.0.1 (patch → patch)\n- **Blocked**: v1.0.0 → v1.1.0 (patch → minor)\n\nThis prevents unexpected breaking changes for teams that demand patch-level versioning."
-    },
-    {
-      "description": "Prevent patch → major upgrades for renovate-config: Block teams using patch versions from getting major updates. This prevents unexpected version type changes.",
-      "matchPackageNames": [
-        "bcgov/renovate-config"
-      ],
-      "matchCurrentVersion": "/^v?\\d+\\.0\\.\\d+$/",
-      "matchUpdateTypes": [
+        "minor",
         "major"
       ],
       "enabled": false,
       "automerge": false,
       "commitMessageAction": "block",
-      "commitMessageTopic": "patch to major upgrade blocked",
-      "prBody": "## Patch → Major Upgrade Blocked\n\nThis update was blocked because it would change from patch to major version.\n\n### Issue:\n- **Current version**: $currentVersion (patch version)\n- **Requested upgrade**: $newVersion (major version)\n- **Problem**: This would change from patch to major, which is not allowed.\n\n### Solution:\nTeams using patch versions must stay on patch versions:\n- **Allowed**: v1.0.0 → v1.0.1 (patch → patch)\n- **Blocked**: v1.0.0 → v2.0.0 (patch → major)\n\nThis prevents unexpected breaking changes for teams that demand patch-level versioning."
+      "commitMessageTopic": "version level change blocked",
+      "prBody": "## Version Level Change Blocked\n\nThis update was blocked because it would change the version level.\n\n### Issue:\n- **Current version**: $currentVersion (patch level)\n- **Requested upgrade**: $newVersion ($updateType level)\n- **Problem**: This would change from patch level to $updateType level, which is not allowed.\n\n### Solution:\nTeams using patch level versions must stay on patch level:\n- **Allowed**: v1.0.0 → v1.0.1 (patch → patch)\n- **Blocked**: v1.0.0 → v1.1.0 (patch → minor)\n- **Blocked**: v1.0.0 → v2.0.0 (patch → major)\n\nThis prevents unexpected breaking changes for teams that demand patch-level versioning."
     },
     {
-      "description": "Prevent minor → major upgrades for renovate-config: Block teams using minor versions from getting major updates. This prevents unexpected version type changes.",
+      "description": "Prevent version level changes for renovate-config: Teams must stay at their current version level (patch, minor, or major). This prevents unexpected version level changes.",
       "matchPackageNames": [
         "bcgov/renovate-config"
       ],
@@ -251,8 +237,8 @@
       "enabled": false,
       "automerge": false,
       "commitMessageAction": "block",
-      "commitMessageTopic": "minor to major upgrade blocked",
-      "prBody": "## Minor → Major Upgrade Blocked\n\nThis update was blocked because it would change from minor to major version.\n\n### Issue:\n- **Current version**: $currentVersion (minor version)\n- **Requested upgrade**: $newVersion (major version)\n- **Problem**: This would change from minor to major, which is not allowed.\n\n### Solution:\nTeams using minor versions must stay on minor versions:\n- **Allowed**: v1.1.0 → v1.2.0 (minor → minor)\n- **Blocked**: v1.1.0 → v2.0.0 (minor → major)\n\nThis prevents unexpected breaking changes for teams that expect minor-level versioning."
+      "commitMessageTopic": "version level change blocked",
+      "prBody": "## Version Level Change Blocked\n\nThis update was blocked because it would change the version level.\n\n### Issue:\n- **Current version**: $currentVersion (minor level)\n- **Requested upgrade**: $newVersion (major level)\n- **Problem**: This would change from minor level to major level, which is not allowed.\n\n### Solution:\nTeams using minor level versions must stay on minor level:\n- **Allowed**: v1.1.0 → v1.2.0 (minor → minor)\n- **Blocked**: v1.1.0 → v2.0.0 (minor → major)\n\nThis prevents unexpected breaking changes for teams that expect minor-level versioning."
     },
     {
       "description": "Suggest upgrading to versioned config: Encourage teams using main branch to upgrade to stable v1 version for better stability and automatic updates.",

--- a/default.json
+++ b/default.json
@@ -216,11 +216,7 @@
       ],
       "matchCurrentVersion": "/^v?\\d+\\.\\d+\\.\\d+$/",
       "allowedVersions": "/^v?\\d+\\.\\d+\\.\\d+$/",
-      "enabled": true,
-      "automerge": false,
-      "commitMessageAction": "block",
-      "commitMessageTopic": "decimal precision change blocked",
-      "prBody": "## Decimal Precision Change Blocked\n\nThis update was blocked because it would change the decimal precision.\n\n### Issue:\n- **Current version**: $currentVersion (3 decimals)\n- **Requested upgrade**: $newVersion (different precision)\n- **Problem**: This would change the decimal precision, which is not allowed.\n\n### Solution:\nTeams using 3-decimal versions must stay on 3-decimal versions:\n- **Allowed**: v1.0.0 → v1.0.1 (3 decimals → 3 decimals)\n- **Allowed**: v1.0.0 → v1.1.0 (3 decimals → 3 decimals)\n- **Allowed**: v1.0.0 → v2.0.0 (3 decimals → 3 decimals)\n- **Blocked**: v1.0.0 → v1.2 (3 decimals → 2 decimals)\n\nThis prevents unexpected version format changes."
+      "enabled": true
     },
     {
       "description": "Suggest upgrading to versioned config: Encourage teams using main branch to upgrade to stable v1 version for better stability and automatic updates.",

--- a/default.json
+++ b/default.json
@@ -210,6 +210,21 @@
       "groupSlug": "cicd"
     },
     {
+      "description": "Prevent invalid version upgrades for renovate-config: Block updates that would violate semantic versioning rules (e.g., v1.0.0 → v1.2.0). This prevents teams from getting unexpected minor/major updates when they expect patch updates.",
+      "matchPackageNames": [
+        "bcgov/renovate-config"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "major"
+      ],
+      "enabled": false,
+      "automerge": false,
+      "commitMessageAction": "block",
+      "commitMessageTopic": "invalid version upgrade",
+      "prBody": "## Invalid Version Upgrade Blocked\n\nThis update was blocked because it would violate semantic versioning rules.\n\n### Issue:\n- **Current version**: $currentVersion\n- **Requested upgrade**: $newVersion\n- **Problem**: This would be a $updateType upgrade, which is not allowed for renovate-config.\n\n### Solution:\nRenovate config updates must follow strict semantic versioning:\n- **Patch updates** (v1.0.0 → v1.0.1): Allowed\n- **Minor updates** (v1.0.0 → v1.1.0): Blocked\n- **Major updates** (v1.0.0 → v2.0.0): Blocked\n\nThis prevents teams from getting unexpected breaking changes."
+    },
+    {
       "description": "Suggest upgrading to versioned config: Encourage teams using main branch to upgrade to stable v1 version for better stability and automatic updates.",
       "matchFileNames": [
         "renovate.json"

--- a/default.json
+++ b/default.json
@@ -210,19 +210,49 @@
       "groupSlug": "cicd"
     },
     {
-      "description": "Prevent invalid version upgrades for renovate-config: Block updates that would violate semantic versioning rules (e.g., v1.0.0 → v1.2.0). This prevents teams from getting unexpected minor/major updates when they expect patch updates.",
+      "description": "Prevent patch → minor upgrades for renovate-config: Block teams using patch versions from getting minor updates. This prevents unexpected version type changes.",
       "matchPackageNames": [
         "bcgov/renovate-config"
       ],
+      "matchCurrentVersion": "/^v?\\d+\\.0\\.\\d+$/",
       "matchUpdateTypes": [
-        "minor",
+        "minor"
+      ],
+      "enabled": false,
+      "automerge": false,
+      "commitMessageAction": "block",
+      "commitMessageTopic": "patch to minor upgrade blocked",
+      "prBody": "## Patch → Minor Upgrade Blocked\n\nThis update was blocked because it would change from patch to minor version.\n\n### Issue:\n- **Current version**: $currentVersion (patch version)\n- **Requested upgrade**: $newVersion (minor version)\n- **Problem**: This would change from patch to minor, which is not allowed.\n\n### Solution:\nTeams using patch versions must stay on patch versions:\n- **Allowed**: v1.0.0 → v1.0.1 (patch → patch)\n- **Blocked**: v1.0.0 → v1.1.0 (patch → minor)\n\nThis prevents unexpected breaking changes for teams that demand patch-level versioning."
+    },
+    {
+      "description": "Prevent patch → major upgrades for renovate-config: Block teams using patch versions from getting major updates. This prevents unexpected version type changes.",
+      "matchPackageNames": [
+        "bcgov/renovate-config"
+      ],
+      "matchCurrentVersion": "/^v?\\d+\\.0\\.\\d+$/",
+      "matchUpdateTypes": [
         "major"
       ],
       "enabled": false,
       "automerge": false,
       "commitMessageAction": "block",
-      "commitMessageTopic": "invalid version upgrade",
-      "prBody": "## Invalid Version Upgrade Blocked\n\nThis update was blocked because it would violate semantic versioning rules.\n\n### Issue:\n- **Current version**: $currentVersion\n- **Requested upgrade**: $newVersion\n- **Problem**: This would be a $updateType upgrade, which is not allowed for renovate-config.\n\n### Solution:\nRenovate config updates must follow strict semantic versioning:\n- **Patch updates** (v1.0.0 → v1.0.1): Allowed\n- **Minor updates** (v1.0.0 → v1.1.0): Blocked\n- **Major updates** (v1.0.0 → v2.0.0): Blocked\n\nThis prevents teams from getting unexpected breaking changes."
+      "commitMessageTopic": "patch to major upgrade blocked",
+      "prBody": "## Patch → Major Upgrade Blocked\n\nThis update was blocked because it would change from patch to major version.\n\n### Issue:\n- **Current version**: $currentVersion (patch version)\n- **Requested upgrade**: $newVersion (major version)\n- **Problem**: This would change from patch to major, which is not allowed.\n\n### Solution:\nTeams using patch versions must stay on patch versions:\n- **Allowed**: v1.0.0 → v1.0.1 (patch → patch)\n- **Blocked**: v1.0.0 → v2.0.0 (patch → major)\n\nThis prevents unexpected breaking changes for teams that demand patch-level versioning."
+    },
+    {
+      "description": "Prevent minor → major upgrades for renovate-config: Block teams using minor versions from getting major updates. This prevents unexpected version type changes.",
+      "matchPackageNames": [
+        "bcgov/renovate-config"
+      ],
+      "matchCurrentVersion": "/^v?\\d+\\.\\d+\\.0$/",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false,
+      "automerge": false,
+      "commitMessageAction": "block",
+      "commitMessageTopic": "minor to major upgrade blocked",
+      "prBody": "## Minor → Major Upgrade Blocked\n\nThis update was blocked because it would change from minor to major version.\n\n### Issue:\n- **Current version**: $currentVersion (minor version)\n- **Requested upgrade**: $newVersion (major version)\n- **Problem**: This would change from minor to major, which is not allowed.\n\n### Solution:\nTeams using minor versions must stay on minor versions:\n- **Allowed**: v1.1.0 → v1.2.0 (minor → minor)\n- **Blocked**: v1.1.0 → v2.0.0 (minor → major)\n\nThis prevents unexpected breaking changes for teams that expect minor-level versioning."
     },
     {
       "description": "Suggest upgrading to versioned config: Encourage teams using main branch to upgrade to stable v1 version for better stability and automatic updates.",

--- a/default.json
+++ b/default.json
@@ -210,35 +210,17 @@
       "groupSlug": "cicd"
     },
     {
-      "description": "Prevent version level changes for renovate-config: Teams must stay at their current version level (patch, minor, or major). This prevents unexpected version level changes.",
+      "description": "Prevent decimal precision changes for renovate-config: Teams must stay at the same decimal precision level (e.g., v1.0.0 stays as 3 decimals, v1.2 stays as 2 decimals). This prevents unexpected version format changes.",
       "matchPackageNames": [
         "bcgov/renovate-config"
       ],
-      "matchCurrentVersion": "/^v?\\d+\\.0\\.\\d+$/",
-      "matchUpdateTypes": [
-        "minor",
-        "major"
-      ],
-      "enabled": false,
+      "matchCurrentVersion": "/^v?\\d+\\.\\d+\\.\\d+$/",
+      "allowedVersions": "/^v?\\d+\\.\\d+\\.\\d+$/",
+      "enabled": true,
       "automerge": false,
       "commitMessageAction": "block",
-      "commitMessageTopic": "version level change blocked",
-      "prBody": "## Version Level Change Blocked\n\nThis update was blocked because it would change the version level.\n\n### Issue:\n- **Current version**: $currentVersion (patch level)\n- **Requested upgrade**: $newVersion ($updateType level)\n- **Problem**: This would change from patch level to $updateType level, which is not allowed.\n\n### Solution:\nTeams using patch level versions must stay on patch level:\n- **Allowed**: v1.0.0 → v1.0.1 (patch → patch)\n- **Blocked**: v1.0.0 → v1.1.0 (patch → minor)\n- **Blocked**: v1.0.0 → v2.0.0 (patch → major)\n\nThis prevents unexpected breaking changes for teams that demand patch-level versioning."
-    },
-    {
-      "description": "Prevent version level changes for renovate-config: Teams must stay at their current version level (patch, minor, or major). This prevents unexpected version level changes.",
-      "matchPackageNames": [
-        "bcgov/renovate-config"
-      ],
-      "matchCurrentVersion": "/^v?\\d+\\.\\d+\\.0$/",
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "enabled": false,
-      "automerge": false,
-      "commitMessageAction": "block",
-      "commitMessageTopic": "version level change blocked",
-      "prBody": "## Version Level Change Blocked\n\nThis update was blocked because it would change the version level.\n\n### Issue:\n- **Current version**: $currentVersion (minor level)\n- **Requested upgrade**: $newVersion (major level)\n- **Problem**: This would change from minor level to major level, which is not allowed.\n\n### Solution:\nTeams using minor level versions must stay on minor level:\n- **Allowed**: v1.1.0 → v1.2.0 (minor → minor)\n- **Blocked**: v1.1.0 → v2.0.0 (minor → major)\n\nThis prevents unexpected breaking changes for teams that expect minor-level versioning."
+      "commitMessageTopic": "decimal precision change blocked",
+      "prBody": "## Decimal Precision Change Blocked\n\nThis update was blocked because it would change the decimal precision.\n\n### Issue:\n- **Current version**: $currentVersion (3 decimals)\n- **Requested upgrade**: $newVersion (different precision)\n- **Problem**: This would change the decimal precision, which is not allowed.\n\n### Solution:\nTeams using 3-decimal versions must stay on 3-decimal versions:\n- **Allowed**: v1.0.0 → v1.0.1 (3 decimals → 3 decimals)\n- **Allowed**: v1.0.0 → v1.1.0 (3 decimals → 3 decimals)\n- **Allowed**: v1.0.0 → v2.0.0 (3 decimals → 3 decimals)\n- **Blocked**: v1.0.0 → v1.2 (3 decimals → 2 decimals)\n\nThis prevents unexpected version format changes."
     },
     {
       "description": "Suggest upgrading to versioned config: Encourage teams using main branch to upgrade to stable v1 version for better stability and automatic updates.",


### PR DESCRIPTION
# Body
## Summary

Add branch protection rule to prevent teams from getting unexpected version format changes. This ensures teams stay at their chosen decimal precision level.

## Changes

- Add `allowedVersions` regex rule for `bcgov/renovate-config`
- Prevent decimal precision changes (e.g., v1.0.0 → v1.2)
- Allow same-precision updates (e.g., v1.0.0 → v1.0.1, v1.1.0, v2.0.0)
- Block precision changes that could break team expectations

## Problem Solved

The `quickstart-openshift` repository was getting PRs to upgrade from `v1.0.0` to `v1.2`, which changes from 3 decimals to 2 decimals. This violates the principle that teams should stay at their chosen version precision level.

## Technical Details

- **Rule**: `allowedVersions: "/^v?\\d+\\.\\d+\\.\\d+$/"` for 3-decimal versions
- **Effect**: Teams using `v1.0.0` only get 3-decimal updates
- **Prevents**: `v1.0.0` → `v1.2` (3 decimals → 2 decimals)
- **Allows**: `v1.0.0` → `v1.0.1`, `v1.1.0`, `v2.0.0` (all 3 decimals)

## Benefits

- **Consistent versioning**: Teams stay at their chosen precision level
- **No unexpected changes**: Prevents format changes that could break expectations
- **Maintains trust**: Teams get the version format they expect
- **Fixes quickstart-openshift**: Resolves the specific issue that triggered this fix