### PR TITLE
fix: add service container unpinning rule

### DIFF
--- a/default.json
+++ b/default.json
@@ -90,11 +90,14 @@
       "pinDigests": false
     },
     {
-      "description": "Unpin containers: Docker images are handled by image tags rather than digests. Container registries provide their own security guarantees through signed tags.",
+      "description": "Unpin containers: Docker images and service containers are handled by image tags rather than digests. Container registries provide their own security guarantees through signed tags.",
       "matchManagers": [
         "dockerfile",
         "docker-compose",
         "kubernetes"
+      ],
+      "matchDepTypes": [
+        "service"
       ],
       "pinDigests": false
     },
@@ -108,13 +111,7 @@
       ],
       "pinDigests": false
     },
-    {
-      "description": "Unpin service containers: Service containers (like postgres, redis, etc.) are handled by image tags rather than digests. These are runtime dependencies that should use stable tags.",
-      "matchDepTypes": [
-        "service"
-      ],
-      "pinDigests": false
-    },
+
     {
       "description": "Prevent config preset pinning: Stop Renovate from trying to pin bcgov/renovate-config as a dependency. Config presets are references, not dependencies that need pinning.",
       "matchPackageNames": [

--- a/default.json
+++ b/default.json
@@ -90,12 +90,16 @@
       "pinDigests": false
     },
     {
-      "description": "Unpin containers: Docker images and service containers are handled by image tags rather than digests. Container registries provide their own security guarantees through signed tags.",
+      "description": "Unpin containers: Docker images are handled by image tags rather than digests. Container registries provide their own security guarantees through signed tags.",
       "matchManagers": [
         "dockerfile",
         "docker-compose",
         "kubernetes"
       ],
+      "pinDigests": false
+    },
+    {
+      "description": "Unpin service containers: Service containers (like postgres, redis, etc.) are handled by image tags rather than digests. These are runtime dependencies that should use stable tags.",
       "matchDepTypes": [
         "service"
       ],
@@ -111,7 +115,6 @@
       ],
       "pinDigests": false
     },
-
     {
       "description": "Prevent config preset pinning: Stop Renovate from trying to pin bcgov/renovate-config as a dependency. Config presets are references, not dependencies that need pinning.",
       "matchPackageNames": [

--- a/default.json
+++ b/default.json
@@ -109,6 +109,13 @@
       "pinDigests": false
     },
     {
+      "description": "Unpin service containers: Service containers (like postgres, redis, etc.) are handled by image tags rather than digests. These are runtime dependencies that should use stable tags.",
+      "matchDepTypes": [
+        "service"
+      ],
+      "pinDigests": false
+    },
+    {
       "description": "Prevent config preset pinning: Stop Renovate from trying to pin bcgov/renovate-config as a dependency. Config presets are references, not dependencies that need pinning.",
       "matchPackageNames": [
         "bcgov/renovate-config"


### PR DESCRIPTION
## Fix Service Container Pinning Issue

### Problem:
Some downstream repositories are getting service container pinning PRs despite our infrastructure unpinning rules:
- Service containers (like postgres, redis) are detected as 'service' type
- Our unpinning rules only covered dockerfile, docker-compose, kubernetes managers
- Service containers should use stable tags, not digests

### Solution:
Add unpinning rule for service containers:
- New rule: unpin all 'service' type containers
- This covers postgres, redis, and other service containers
- Service containers should use stable tags, not digests

### Testing:
- Validation script passes with no conflicts
- Integration test passes
- No pinning conflicts detected

### Files Changed:
- default.json - Added service container unpinning rule

This should fix service container pinning issues across all downstream repositories.