### PR TITLE
refactor: simplify release workflow by removing changelog generation

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -134,15 +134,27 @@ jobs:
           set -e
           echo "📝 Generating changelog for version ${{ steps.version.outputs.tag }}..."
 
-          # Generate changelog for latest release only, and prepend to existing CHANGELOG.md
+          # Generate changelog for latest release only
           npx conventional-changelog --preset angular --release-count 1 --output-file CHANGELOG.latest.md
+          
+          # Check if changelog was generated successfully
+          if [ ! -f CHANGELOG.latest.md ] || [ ! -s CHANGELOG.latest.md ]; then
+            echo "⚠️  No conventional commits found, creating minimal changelog"
+            echo "# [${{ steps.version.outputs.tag }}] - $(date +%Y-%m-%d)" > CHANGELOG.latest.md
+            echo "" >> CHANGELOG.latest.md
+            echo "### Changes" >> CHANGELOG.latest.md
+            echo "" >> CHANGELOG.latest.md
+            echo "- Manual release" >> CHANGELOG.latest.md
+          fi
+          
+          # Prepend to existing CHANGELOG.md or create new one
           if [ -f CHANGELOG.md ]; then
             cat CHANGELOG.latest.md CHANGELOG.md > CHANGELOG.new.md
           else
             cat CHANGELOG.latest.md > CHANGELOG.new.md
           fi
           mv CHANGELOG.new.md CHANGELOG.md
-          rm CHANGELOG.latest.md
+          rm -f CHANGELOG.latest.md
 
           echo "✅ Changelog generated successfully"
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Fetch all tags
         run: |
-          # Fetch all tags to ensure changelog generation and version comparison have access to the complete tag history
+          # Fetch all tags to ensure version comparison has access to the complete tag history
           git fetch --tags --force
           echo "Available tags:"
           git tag -l
@@ -210,8 +210,8 @@ jobs:
             ```
             Benefits: stable updates, automatic upgrades, no breaking changes.
 
-            ### Changelog
-            See the [CHANGELOG.md](https://github.com/bcgov/renovate-config/blob/main/CHANGELOG.md) for detailed changes.
+                        ### Changes
+            See the [GitHub releases](https://github.com/bcgov/renovate-config/releases) for detailed changes.
 
       - name: Create Major/Minor Version Tags
         if: steps.version.outputs.version != ''

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -128,11 +128,7 @@ jobs:
           echo "version=$VERSION_NUM" >> $GITHUB_OUTPUT
           echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
 
-      - name: Skip Changelog Generation
-        if: steps.version.outputs.version != ''
-        run: |
-          echo "📝 Skipping changelog generation - GitHub releases provide changelog automatically"
-          echo "✅ Release workflow focuses on versioning and tagging only"
+      
 
       - name: Create Git Tag
         if: steps.version.outputs.version != ''

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -51,53 +51,53 @@ jobs:
         run: |
           set -e
           echo "🔍 Calculating next version based on conventional commits..."
-          
+
           # Check if manual version override is provided
           if [ -n "${{ github.event.inputs.version_override }}" ]; then
             echo "📋 Using manual version override: ${{ github.event.inputs.version_override }}"
             VERSION_OVERRIDE="${{ github.event.inputs.version_override }}"
-            
+
             # Validate version format (should start with 'v' and be semantic)
             if [[ ! "$VERSION_OVERRIDE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "❌ Invalid version format: $VERSION_OVERRIDE"
               echo "Expected format: vX.Y.Z (e.g., v1.2.3)"
               exit 1
             fi
-            
+
             # Extract version numbers from override
             VERSION_NUM=${VERSION_OVERRIDE#v}
             TAG_NAME="$VERSION_OVERRIDE"
-            
+
             echo "📋 Manual version: $TAG_NAME"
             echo "version=$VERSION_NUM" >> $GITHUB_OUTPUT
             echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
             exit 0
           fi
- 
+
           # Automatic version calculation
           echo "📋 Calculating automatic version..."
-          
+
           # Get the recommended bump type (major, minor, patch)
           BUMP_TYPE=$(npx conventional-recommended-bump --preset angular)
           echo "📋 Recommended bump type: $BUMP_TYPE"
- 
+
           if [ -z "$BUMP_TYPE" ]; then
             echo "❌ No new version to release"
             echo "version=" >> $GITHUB_OUTPUT
             echo "tag=" >> $GITHUB_OUTPUT
             exit 0
           fi
- 
+
           # Get the latest version from git tags
           LATEST_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "📋 Latest version: $LATEST_VERSION"
- 
+
           # Extract version numbers
           LATEST_NUM=${LATEST_VERSION#v}
           MAJOR=$(echo "$LATEST_NUM" | cut -d. -f1)
           MINOR=$(echo "$LATEST_NUM" | cut -d. -f2)
           PATCH=$(echo "$LATEST_NUM" | cut -d. -f3)
- 
+
           # Calculate next version based on bump type
           case "$BUMP_TYPE" in
             "major")
@@ -117,18 +117,16 @@ jobs:
               exit 1
               ;;
           esac
- 
+
           # Create new version and tag
           VERSION_NUM="$MAJOR.$MINOR.$PATCH"
           TAG_NAME="v$VERSION_NUM"
- 
+
           echo "📋 Next version: $TAG_NAME"
- 
+
           # Output for other steps
           echo "version=$VERSION_NUM" >> $GITHUB_OUTPUT
           echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
-
-      
 
       - name: Create Git Tag
         if: steps.version.outputs.version != ''
@@ -206,7 +204,7 @@ jobs:
             ```
             Benefits: stable updates, automatic upgrades, no breaking changes.
 
-                        ### Changes
+            ### Changes
             See the [GitHub releases](https://github.com/bcgov/renovate-config/releases) for detailed changes.
 
       - name: Create Major/Minor Version Tags

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -42,10 +42,6 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Setup Node.js (for version calculation only)
-        run: |
-          echo "Node.js setup complete - using for version calculation only"
-
       - name: Calculate Next Version
         id: version
         run: |
@@ -54,17 +50,15 @@ jobs:
 
           # Check if manual version override is provided
           if [ -n "${{ github.event.inputs.version_override }}" ]; then
-            echo "📋 Using manual version override: ${{ github.event.inputs.version_override }}"
             VERSION_OVERRIDE="${{ github.event.inputs.version_override }}"
 
-            # Validate version format (should start with 'v' and be semantic)
+            # Validate version format
             if [[ ! "$VERSION_OVERRIDE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "❌ Invalid version format: $VERSION_OVERRIDE"
               echo "Expected format: vX.Y.Z (e.g., v1.2.3)"
               exit 1
             fi
 
-            # Extract version numbers from override
             VERSION_NUM=${VERSION_OVERRIDE#v}
             TAG_NAME="$VERSION_OVERRIDE"
 
@@ -74,10 +68,7 @@ jobs:
             exit 0
           fi
 
-          # Automatic version calculation
-          echo "📋 Calculating automatic version..."
-
-          # Get the recommended bump type (major, minor, patch)
+          # Get the recommended bump type
           BUMP_TYPE=$(npx conventional-recommended-bump --preset angular)
           echo "📋 Recommended bump type: $BUMP_TYPE"
 
@@ -92,7 +83,6 @@ jobs:
           LATEST_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "📋 Latest version: $LATEST_VERSION"
 
-          # Extract version numbers
           LATEST_NUM=${LATEST_VERSION#v}
           MAJOR=$(echo "$LATEST_NUM" | cut -d. -f1)
           MINOR=$(echo "$LATEST_NUM" | cut -d. -f2)
@@ -118,13 +108,10 @@ jobs:
               ;;
           esac
 
-          # Create new version and tag
           VERSION_NUM="$MAJOR.$MINOR.$PATCH"
           TAG_NAME="v$VERSION_NUM"
 
           echo "📋 Next version: $TAG_NAME"
-
-          # Output for other steps
           echo "version=$VERSION_NUM" >> $GITHUB_OUTPUT
           echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
 
@@ -139,15 +126,12 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
-          # Clean up any existing local tag to avoid conflicts
-          echo "🧹 Cleaning up any existing local tag..."
+          # Clean up any existing local tag
           git tag -d "$TAG_NAME" 2>/dev/null || echo "No existing local tag to remove"
 
-          # Create new tag
+          # Create and push tag
           git tag "$TAG_NAME"
           echo "✅ Tag created locally: $TAG_NAME"
-
-          # Push tag with robust error handling
           echo "📤 Pushing tag to remote..."
           if git push origin "$TAG_NAME"; then
             echo "✅ Tag pushed successfully: $TAG_NAME"
@@ -215,11 +199,9 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
-          # Get the version that was just created
           VERSION="${{ steps.version.outputs.tag }}"
           echo "🏷️  Creating major/minor tags for version: $VERSION"
 
-          # Extract major and minor versions
           VERSION_NUM=${VERSION#v}
           MAJOR_VERSION="v${VERSION_NUM%%.*}"
           MINOR_VERSION="v${VERSION_NUM%.*}"
@@ -227,7 +209,7 @@ jobs:
           echo "📋 Major version: $MAJOR_VERSION"
           echo "📋 Minor version: $MINOR_VERSION"
 
-          # Create/update major version tag (e.g., v1)
+          # Create/update major version tag
           echo "🔄 Updating $MAJOR_VERSION tag..."
           git tag -f $MAJOR_VERSION
           if git push origin $MAJOR_VERSION --force; then
@@ -240,7 +222,7 @@ jobs:
             exit 1
           fi
 
-          # Create/update minor version tag (e.g., v1.1)
+          # Create/update minor version tag
           echo "🔄 Updating $MINOR_VERSION tag..."
           git tag -f $MINOR_VERSION
           if git push origin $MINOR_VERSION --force; then

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -42,9 +42,9 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install conventional-changelog tools
+      - name: Setup Node.js (for version calculation only)
         run: |
-          npm install -g conventional-changelog-cli@4.1.0 conventional-recommended-bump@6.1.0 conventional-changelog-angular@5.0.12
+          echo "Node.js setup complete - using for version calculation only"
 
       - name: Calculate Next Version
         id: version
@@ -128,36 +128,11 @@ jobs:
           echo "version=$VERSION_NUM" >> $GITHUB_OUTPUT
           echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
 
-      - name: Generate Changelog
+      - name: Skip Changelog Generation
         if: steps.version.outputs.version != ''
         run: |
-          set -e
-          echo "📝 Generating changelog for version ${{ steps.version.outputs.tag }}..."
-
-          # Generate changelog for latest release only
-          npx conventional-changelog --preset angular --release-count 1 --output-file CHANGELOG.latest.md
-          
-          # Check if changelog was generated successfully
-          echo "Checking if changelog was generated..."
-          if [ ! -f CHANGELOG.latest.md ] || [ ! -s CHANGELOG.latest.md ]; then
-            echo "⚠️  No conventional commits found, creating minimal changelog"
-            echo "# [${{ steps.version.outputs.tag }}] - $(date -u +%Y-%m-%d)" > CHANGELOG.latest.md
-            echo "" >> CHANGELOG.latest.md
-            echo "### Changes" >> CHANGELOG.latest.md
-            echo "" >> CHANGELOG.latest.md
-            echo "- Manual release" >> CHANGELOG.latest.md
-          fi
-          
-          # Prepend to existing CHANGELOG.md or create new one
-          if [ -f CHANGELOG.md ]; then
-            cat CHANGELOG.latest.md CHANGELOG.md > CHANGELOG.new.md
-          else
-            cat CHANGELOG.latest.md > CHANGELOG.new.md
-          fi
-          mv CHANGELOG.new.md CHANGELOG.md
-          rm -f CHANGELOG.latest.md
-
-          echo "✅ Changelog generated successfully"
+          echo "📝 Skipping changelog generation - GitHub releases provide changelog automatically"
+          echo "✅ Release workflow focuses on versioning and tagging only"
 
       - name: Create Git Tag
         if: steps.version.outputs.version != ''

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -138,9 +138,10 @@ jobs:
           npx conventional-changelog --preset angular --release-count 1 --output-file CHANGELOG.latest.md
           
           # Check if changelog was generated successfully
+          echo "Checking if changelog was generated..."
           if [ ! -f CHANGELOG.latest.md ] || [ ! -s CHANGELOG.latest.md ]; then
             echo "⚠️  No conventional commits found, creating minimal changelog"
-            echo "# [${{ steps.version.outputs.tag }}] - $(date +%Y-%m-%d)" > CHANGELOG.latest.md
+            echo "# [${{ steps.version.outputs.tag }}] - $(date -u +%Y-%m-%d)" > CHANGELOG.latest.md
             echo "" >> CHANGELOG.latest.md
             echo "### Changes" >> CHANGELOG.latest.md
             echo "" >> CHANGELOG.latest.md


### PR DESCRIPTION
## Problem

The release workflow was maintaining changelog files, which is an antipattern. GitHub releases already provide changelog information automatically.

## Solution

* Removed changelog generation entirely
* Simplified workflow to focus on versioning and tagging only
* Eliminated maintenance overhead of changelog files
* Reduced workflow complexity and potential failure points

## Benefits

* ✅ **No maintenance overhead** - GitHub releases handle changelog automatically
* ✅ **Simplified workflow** - fewer steps, fewer failure points
* ✅ **Best practices** - no redundant changelog file antipattern
* ✅ **Consistent information** - single source of truth in GitHub releases

## Testing

This change simplifies the release workflow while maintaining all versioning functionality. Users can find changelog information in the GitHub releases page.