### PR TITLE
fix: simplify regex patterns in rules-actions.json5

### DIFF
--- a/rules-actions.json5
+++ b/rules-actions.json5
@@ -26,9 +26,9 @@
         "replacement"
       ],
       "matchPackageNames": [
-        "/^actions\\//",  // GitHub's official actions
-        "/^docker\\//",   // Docker's official actions
-        "/^github\\//"    // GitHub's other official actions
+        "actions/",
+        "docker/",
+        "github/"
       ]
     },
     // Group all other GitHub Actions dependencies (pinned with SHA digests for security)
@@ -53,9 +53,9 @@
         "replacement"
       ],
       "matchPackageNames": [
-        "!/^actions\\//",  // Exclude allowlisted orgs
-        "!/^docker\\//",   // Exclude allowlisted orgs
-        "!/^github\\//"    // Exclude allowlisted orgs
+        "!actions/",
+        "!docker/",
+        "!github/"
       ]
     }
     // Add additional rules below as needed

--- a/rules-actions.json5
+++ b/rules-actions.json5
@@ -26,9 +26,9 @@
         "replacement"
       ],
       "matchPackageNames": [
-        "actions/",
-        "docker/",
-        "github/"
+        "^actions/",
+        "^docker/",
+        "^github/"
       ]
     },
     // Group all other GitHub Actions dependencies (pinned with SHA digests for security)
@@ -53,9 +53,9 @@
         "replacement"
       ],
       "matchPackageNames": [
-        "!actions/",
-        "!docker/",
-        "!github/"
+        "!^actions/",
+        "!^docker/",
+        "!^github/"
       ]
     }
     // Add additional rules below as needed


### PR DESCRIPTION
This PR fixes the preset loading issue by simplifying the regex patterns in matchPackageNames while keeping the file as JSON5 format.

The complex regex patterns like  were causing parsing issues. Simplified to  which should work for the intended use case.

Fixes: https://github.com/bcgov/quickstart-aws-sql/issues/169