### PR TITLE
feat: add package rule to update unversioned renovate-config references to v1

### DIFF
--- a/.copilot-instructions.md
+++ b/.copilot-instructions.md
@@ -20,6 +20,18 @@
 - **NEVER modify GitHub Actions workflows without explicit permission**
 - **NEVER change CI/CD configurations without explicit permission**
 
+### Pull Request Management
+- **ALWAYS use file-based method for PR body updates to avoid shell escaping issues:**
+  ```bash
+  # Create PR body file
+  echo 'PR body content here' > pr_body.md
+  # Update PR with file
+  gh pr edit --title "Title" --body-file pr_body.md
+  # Clean up
+  rm pr_body.md
+  ```
+- **NEVER use inline --body with special characters** as it causes shell escaping problems
+
 ## General Preferences
 - Prefer incremental, verified changes over large refactoring
 - Always ensure application functionality before proceeding

--- a/.copilot-instructions.md
+++ b/.copilot-instructions.md
@@ -11,6 +11,10 @@
 - **NEVER force-push to main branch**
 - **ALWAYS ask before making changes that could break downstream repositories**
 - **ALWAYS test changes locally first when possible**
+- **ALWAYS validate Renovate configurations locally before committing:**
+  ```bash
+  npx --yes --package renovate --- "renovate-config-validator --strict default.json renovate.json rules-*.json5"
+  ```
 
 ### Workflow & CI/CD
 - **NEVER modify GitHub Actions workflows without explicit permission**

--- a/default.json
+++ b/default.json
@@ -184,8 +184,11 @@
       "matchFileNames": [
         "renovate.json"
       ],
-      "matchPackageNames": [
-        "bcgov/renovate-config"
+      "matchStrings": [
+        "github>bcgov/renovate-config\""
+      ],
+      "excludeMatchStrings": [
+        "github>bcgov/renovate-config#"
       ],
       "matchUpdateTypes": [
         "major",

--- a/default.json
+++ b/default.json
@@ -180,29 +180,6 @@
       "enabled": true
     },
     {
-      "description": "Suggest upgrading to versioned config: Encourage teams using main branch to upgrade to stable v1 version for better stability and automatic updates.",
-      "matchFileNames": [
-        "renovate.json"
-      ],
-      "matchPackageNames": [
-        "github>bcgov/renovate-config"
-      ],
-      "matchCurrentVersion": "!/^v\\d+\\.\\d+(\\.\\d+)?$/",
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch"
-      ],
-      "enabled": true,
-      "automerge": false,
-      "commitMessageAction": "upgrade",
-      "commitMessageTopic": "renovate config",
-      "commitMessageExtra": "to v1",
-      "prCreation": "not-pending",
-      "recreateWhen": "never",
-      "prBody": "## Upgrade to Versioned Renovate Config\n\nThis PR upgrades your Renovate configuration from the main branch to the stable v1 version.\n\n### Benefits:\n- ✅ **Stable updates** - get tested releases, not development changes\n- ✅ **Automatic upgrades** - get new v1.x.x releases automatically\n- ✅ **No breaking changes** - won't get v2+ breaking changes\n- ✅ **Easy rollback** - can pin to specific version if needed\n\n### What Changes:\n- `github>bcgov/renovate-config` → `github>bcgov/renovate-config#v1`\n\nThis change is recommended for production stability. The v1 version receives regular updates and bug fixes while maintaining backward compatibility."
-    },
-    {
       "description": "Update unversioned renovate-config references to v1: Target repositories using the unversioned reference and update them to use the stable v1 tag, while ignoring repositories already using specific version tags.",
       "matchFileNames": [
         "renovate.json"

--- a/default.json
+++ b/default.json
@@ -184,6 +184,7 @@
       "matchFileNames": [
         "renovate.json"
       ],
+      "matchPackageNames": [
         "github>bcgov/renovate-config"
       ],
       "excludeMatchStrings": [
@@ -202,6 +203,25 @@
       "prCreation": "not-pending",
       "recreateWhen": "never",
       "prBody": "## Upgrade to Versioned Renovate Config\n\nThis PR upgrades your Renovate configuration from the main branch to the stable v1 version.\n\n### Benefits:\n- ✅ **Stable updates** - get tested releases, not development changes\n- ✅ **Automatic upgrades** - get new v1.x.x releases automatically\n- ✅ **No breaking changes** - won't get v2+ breaking changes\n- ✅ **Easy rollback** - can pin to specific version if needed\n\n### What Changes:\n- `github>bcgov/renovate-config` → `github>bcgov/renovate-config#v1`\n\nThis change is recommended for production stability. The v1 version receives regular updates and bug fixes while maintaining backward compatibility."
+    },
+    {
+      "description": "Update unversioned renovate-config references to v1: Target repositories using the unversioned reference and update them to use the stable v1 tag, while ignoring repositories already using specific version tags.",
+      "matchFileNames": [
+        "renovate.json"
+      ],
+      "matchPackageNames": [
+        "github>bcgov/renovate-config"
+      ],
+      "matchCurrentVersion": "!/^v\\d+\\.\\d+(\\.\\d+)?$/",
+      "allowedVersions": "v1",
+      "enabled": true,
+      "automerge": false,
+      "commitMessageAction": "Update",
+      "commitMessageTopic": "bcgov renovate-config",
+      "commitMessageExtra": "to v1",
+      "prCreation": "not-pending",
+      "recreateWhen": "never",
+      "prBody": "## Update Renovate Config to v1\n\nThis PR updates your Renovate configuration from the unversioned reference to the stable v1 tag.\n\n### What Changes:\n- `github>bcgov/renovate-config` → `github>bcgov/renovate-config#v1`\n\n### Benefits:\n- ✅ **Stable updates** - get tested releases, not development changes\n- ✅ **Automatic upgrades** - get new v1.x.x releases automatically\n- ✅ **No breaking changes** - won't get v2+ breaking changes\n- ✅ **Easy rollback** - can pin to specific version if needed\n\nThis change is recommended for production stability. The v1 version receives regular updates and bug fixes while maintaining backward compatibility."
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -187,9 +187,7 @@
       "matchPackageNames": [
         "github>bcgov/renovate-config"
       ],
-      "excludeMatchStrings": [
-        "github>bcgov/renovate-config#"
-      ],
+      "matchCurrentVersion": "!/^v\\d+\\.\\d+(\\.\\d+)?$/",
       "matchUpdateTypes": [
         "major",
         "minor",

--- a/default.json
+++ b/default.json
@@ -184,8 +184,7 @@
       "matchFileNames": [
         "renovate.json"
       ],
-      "matchStrings": [
-        "github>bcgov/renovate-config\""
+        "github>bcgov/renovate-config"
       ],
       "excludeMatchStrings": [
         "github>bcgov/renovate-config#"

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Repository-specific Renovate config. Extends the shared bcgov/renovate-config preset. Downstream repos should reference this file for consistent update management.",
   "extends": [
-    "github>bcgov/renovate-config"
+    "github>bcgov/renovate-config#v1"
   ]
 }


### PR DESCRIPTION
## Overview

This PR adds a package rule to automatically send PRs to downstream repositories that are using the unversioned `github>bcgov/renovate-config` reference, encouraging them to upgrade to the stable `github>bcgov/renovate-config#v1` tag.

## What This Does

### Target Repositories
- **Targets**: Repositories using `github>bcgov/renovate-config` (unversioned)
- **Updates to**: `github>bcgov/renovate-config#v1`
- **Ignores**: Repositories already using specific version tags (e.g., `#v1.0.0`, `#v1.0`)

### Package Rule Details
- Uses `matchCurrentVersion: "/^v\\d+\\.\\d+(\\.\\d+)?$/"` to exclude versioned references
- Sets `allowedVersions: "v1"` to only allow updates to the v1 tag
- Includes `recreateWhen: "never"` to ensure one-time PR creation
- Provides clear PR messaging about benefits and changes

## Benefits

- ✅ **Stable updates** - get tested releases, not development changes
- ✅ **Automatic upgrades** - get new v1.x.x releases automatically  
- ✅ **No breaking changes** - won't get v2+ breaking changes
- ✅ **Easy rollback** - can pin to specific version if needed
- ✅ **One-time only** - teams can safely decline by closing the PR

## Versioned Repositories

Repositories already using specific version tags (like `v1.0.0`) will continue to receive updates within their precision level (e.g., `v1.0.0` → `v1.1.0` when released) and are not affected by this rule.

## Testing

- ✅ Configuration validates successfully
- ✅ Local validation added to AI instructions
- ✅ No interference with existing versioned references
