### PR TITLE
fix: add global recreateWhen: never to prevent immortal PRs

### DIFF
--- a/default.json
+++ b/default.json
@@ -44,6 +44,7 @@
   },
   "platform": "github",
   "platformAutomerge": true,
+  "recreateWhen": "never",
   "timezone": "America/Vancouver",
   "schedule": [
     "before 6am every weekday"


### PR DESCRIPTION
## Overview

This PR adds a global `recreateWhen: "never"` setting to prevent immortal PRs that annoy downstream developers.

## The Problem

Downstream repositories were experiencing "immortal" PRs that would reappear after being closed, as seen in [bcgov/nr-pies#50](https://github.com/bcgov/nr-pies/pull/50). This was frustrating for developers who wanted to decline updates.

## The Fix

Added a global setting to ensure PRs are never recreated when closed:

```json
"recreateWhen": "never"
```

## Benefits

- ✅ **Respects developer choice** - closed PRs stay closed
- ✅ **No more immortal PRs** - prevents annoying reappearing PRs
- ✅ **Applies globally** - affects all PRs created by Renovate
- ✅ **Validates successfully** - configuration passes all checks

## Impact

This change will prevent the "immortal" behavior that was causing frustration in downstream repositories. Developers can now safely close PRs without them reappearing.
