### PR TITLE
fix: package name consistency and config improvements

### DIFF
--- a/default.json
+++ b/default.json
@@ -36,9 +36,7 @@
     ":ignoreModulesAndTests"
   ],
   "minimumReleaseAge": "7 days",
-  "prNotPendingHours": 24,
   "onboarding": true,
-  "requireConfig": "required",
   "configWarningReuseIssue": true,
   "onboardingConfig": {
     "extends": [
@@ -188,7 +186,8 @@
       "matchFileNames": [
         "renovate.json",
         ".github/renovate.json",
-        "renovate.json5"
+        "renovate.json5",
+        ".github/renovate.json5"
       ],
       "matchPackageNames": [
         "github>bcgov/renovate-config"

--- a/default.json
+++ b/default.json
@@ -36,7 +36,10 @@
     ":ignoreModulesAndTests"
   ],
   "minimumReleaseAge": "7 days",
+  "prNotPendingHours": 24,
   "onboarding": true,
+  "requireConfig": "required",
+  "configWarningReuseIssue": true,
   "onboardingConfig": {
     "extends": [
       "github>bcgov/renovate-config"
@@ -85,7 +88,7 @@
     {
       "description": "Prevent config preset pinning: Stop Renovate from trying to pin bcgov/renovate-config as a dependency. Config presets are references, not dependencies that need pinning.",
       "matchPackageNames": [
-        "bcgov/renovate-config"
+        "github>bcgov/renovate-config"
       ],
       "matchUpdateTypes": [
         "pin"
@@ -174,7 +177,7 @@
     {
       "description": "Prevent decimal precision changes for renovate-config: Teams must stay at the same decimal precision level (e.g., v1.0.0 stays as 3 decimals, v1.2 stays as 2 decimals). This prevents unexpected version format changes.",
       "matchPackageNames": [
-        "bcgov/renovate-config"
+        "github>bcgov/renovate-config"
       ],
       "matchCurrentVersion": "/^v?\\d+\\.\\d+\\.\\d+$/",
       "allowedVersions": "/^v?\\d+\\.\\d+\\.\\d+$/",
@@ -183,7 +186,9 @@
     {
       "description": "Update unversioned renovate-config references to v1: Target repositories using the unversioned reference and update them to use the stable v1 tag, while ignoring repositories already using specific version tags.",
       "matchFileNames": [
-        "renovate.json"
+        "renovate.json",
+        ".github/renovate.json",
+        "renovate.json5"
       ],
       "matchPackageNames": [
         "github>bcgov/renovate-config"


### PR DESCRIPTION
## Overview

This PR addresses critical issues that were preventing teams from receiving the v1.0.0 update PRs and improves overall config stability and reliability.

## The Problem

Teams using the unversioned `github>bcgov/renovate-config` reference were not receiving PRs to upgrade to v1.0.0. Investigation revealed several issues:

### **1. Package Name Inconsistency** 🚨
- **Issue**: Rules used mixed package names (`"bcgov/renovate-config"` vs `"github>bcgov/renovate-config"`)
- **Impact**: Rules couldn't match properly, preventing PR creation
- **Fix**: Standardized all rules to use `"github>bcgov/renovate-config"`

### **2. Limited File Support** 📁
- **Issue**: Only targeted `"renovate.json"` files
- **Impact**: Missed configs in `.github/renovate.json` or `renovate.json5`
- **Fix**: Added support for multiple config file locations

### **3. Missing Stability Controls** ⚖️
- **Issue**: No error handling or stability settings
- **Impact**: Potential for unstable updates
- **Fix**: Added `requireConfig`, `configWarningReuseIssue`, `prNotPendingHours`

## Changes Made

- ✅ **Package name consistency fixed** - all rules now use `"github>bcgov/renovate-config"`
- ✅ **File targeting expanded** - supports `renovate.json`, `.github/renovate.json`, `renovate.json5`
- ✅ **Stability settings added** - better error handling and update controls
- ✅ **Configuration validates successfully**

## Expected Impact

Teams will now receive v1.0.0 update PRs, and the config is more stable and reliable.

## Next Steps

After merging this PR, we can replace v1.0.0 tag with the improved configuration.