### PR TITLE
fix: use valid version format for customManagers currentValueTemplate

### DIFF
--- a/default.json
+++ b/default.json
@@ -177,7 +177,7 @@
         "/.github/renovate.json5/"
       ],
       "matchStrings": [
-        "\"github>bcgov/renovate-config\""
+        "\"github>bcgov/renovate-config(?<currentValue>)\""
       ],
       "depNameTemplate": "github>bcgov/renovate-config",
       "currentValueTemplate": "unversioned",

--- a/default.json
+++ b/default.json
@@ -177,10 +177,10 @@
         "/.github/renovate.json5/"
       ],
       "matchStrings": [
-        "\"github>bcgov/renovate-config(?<currentValue>)\""
+        "\"github>bcgov/renovate-config\""
       ],
       "depNameTemplate": "github>bcgov/renovate-config",
-      "currentValueTemplate": "unversioned",
+      "currentValueTemplate": "0.0.0",
       "autoReplaceStringTemplate": "\"github>bcgov/renovate-config#v1\"",
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "bcgov/renovate-config"


### PR DESCRIPTION
## Problem

The  configuration was using  which Renovate considers an invalid version format. This caused the regex manager to skip the unversioned renovate-config references instead of updating them.

## Solution

Changed  from  to  to use a valid version format that Renovate can process.

## Testing

- Configuration validates successfully
- Should now properly trigger PRs for repositories using unversioned  references

This fixes the issue where downstream repositories were not receiving PRs to update their unversioned config references to .