### PR TITLE
fix: use valid branch name for customManagers depNameTemplate

### DIFF
--- a/default.json
+++ b/default.json
@@ -179,7 +179,7 @@
       "matchStrings": [
         "\"github>bcgov/renovate-config\""
       ],
-      "depNameTemplate": "github>bcgov/renovate-config",
+      "depNameTemplate": "renovate-v1-config",
       "currentValueTemplate": "0.0.0",
       "autoReplaceStringTemplate": "\"github>bcgov/renovate-config#v1\"",
       "datasourceTemplate": "github-releases",


### PR DESCRIPTION
## Problem

The  configuration was using  which contains a `>` character. This caused Git branch name creation to fail because it is not a valid character in branch names.

## Solution

Changed to use a valid branch name format.

## Testing

- Configuration validates successfully
- Should now properly create branches and PRs for repositories using unversioned  references

This fixes the issue where downstream repositories were not receiving PRs due to invalid branch name creation.