### PR TITLE
fix: use correct field name for custom manager replacement

### DIFF
--- a/default.json
+++ b/default.json
@@ -181,7 +181,7 @@
       ],
       "depNameTemplate": "renovate-v1-config",
       "currentValueTemplate": "0.0.0",
-      "replaceString": "\"github>bcgov/renovate-config#v1\"",
+      "autoReplaceStringTemplate": "\"github>bcgov/renovate-config#v1\"",
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "bcgov/renovate-config"
     }

--- a/default.json
+++ b/default.json
@@ -177,11 +177,11 @@
         "/.github/renovate.json5/"
       ],
       "matchStrings": [
-        "\"github>bcgov/renovate-config\""
+        "\"github\\>bcgov/renovate-config\""
       ],
       "depNameTemplate": "renovate-v1-config",
       "currentValueTemplate": "0.0.0",
-      "autoReplaceStringTemplate": "\"github>bcgov/renovate-config#v1\"",
+      "replaceString": "\"github>bcgov/renovate-config#v1\"",
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "bcgov/renovate-config"
     }


### PR DESCRIPTION
## What Changed

Fixed the custom manager configuration validation error by using the correct field name.

### Issue:
The  field is not valid for custom managers. The validation was failing with:


### Fix:
Changed from  to  which is the correct field for custom managers.

### Current Configuration:


### Validation:
✅ Config validation now passes successfully

This maintains the same functionality (regex escaping and replacement logic) while using the correct field name for custom managers.