### PR TITLE
fix: correct currentValueTemplate for v1 regex manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -180,7 +180,7 @@
         "\"github\\>bcgov/renovate-config\""
       ],
       "depNameTemplate": "renovate-v1-config",
-      "currentValueTemplate": "0.0.0",
+      "currentValueTemplate": "github>bcgov/renovate-config",
       "autoReplaceStringTemplate": "\"github>{{packageName}}#v1\"",
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "bcgov/renovate-config"


### PR DESCRIPTION
## What Changed

Fixed the regex manager configuration to properly handle v1 migration:

### Issue:
-  was set to  but should match the actual unversioned reference
- This mismatch was causing the regex manager to fail during update processing

### Fix:
- Changed  from  to 
- Now properly matches the unversioned reference being found in renovate.json files

### Why This Should Fix the Problem:
- The regex manager now correctly identifies the current value as the unversioned reference
- This should resolve the "Error updating branch: update failure" during v1 migration
- The manager can now properly perform the update from  to 

This targets the core issue with the v1 migration regex manager.