### PR TITLE
fix: change datasource to github-tags for unversioned references

### DIFF
--- a/default.json
+++ b/default.json
@@ -177,10 +177,9 @@
         "/.github/renovate.json5/"
       ],
       "matchStrings": [
-        "\"github>bcgov/renovate-config\""
+        "\"(?<currentValue>github>bcgov/renovate-config)\""
       ],
       "depNameTemplate": "renovate-v1-config",
-      "currentValueTemplate": "github>bcgov/renovate-config",
       "autoReplaceStringTemplate": "\"github>{{packageName}}#v1\"",
       "datasourceTemplate": "github",
       "packageNameTemplate": "bcgov/renovate-config"

--- a/default.json
+++ b/default.json
@@ -163,16 +163,6 @@
       ],
       "matchCurrentVersion": "/^v?\\d+\\.\\d+\\.\\d+$/",
       "allowedVersions": "/^v?\\d+\\.\\d+\\.\\d+$/",
-      "matchManagers": [
-        "npm",
-        "docker",
-        "github-actions",
-        "helm",
-        "maven",
-        "gradle",
-        "pip",
-        "composer"
-      ],
       "enabled": true
     }
   ],

--- a/default.json
+++ b/default.json
@@ -193,6 +193,7 @@
       "currentValueTemplate": "github>bcgov/renovate-config",
       "autoReplaceStringTemplate": "\"github>{{packageName}}#v1\"",
       "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver",
       "packageNameTemplate": "bcgov/renovate-config"
     }
   ]

--- a/default.json
+++ b/default.json
@@ -182,6 +182,7 @@
       "depNameTemplate": "renovate-v1-config",
       "currentValueTemplate": "github>bcgov/renovate-config",
       "autoReplaceStringTemplate": "\"github>{{packageName}}#v1\"",
+      "datasourceTemplate": "github",
       "packageNameTemplate": "bcgov/renovate-config"
     }
   ]

--- a/default.json
+++ b/default.json
@@ -182,7 +182,7 @@
       "depNameTemplate": "renovate-v1-config",
       "currentValueTemplate": "github>bcgov/renovate-config",
       "autoReplaceStringTemplate": "\"github>{{packageName}}#v1\"",
-      "datasourceTemplate": "github-releases",
+      "datasourceTemplate": "github-tags",
       "packageNameTemplate": "bcgov/renovate-config"
     }
   ]

--- a/default.json
+++ b/default.json
@@ -163,6 +163,16 @@
       ],
       "matchCurrentVersion": "/^v?\\d+\\.\\d+\\.\\d+$/",
       "allowedVersions": "/^v?\\d+\\.\\d+\\.\\d+$/",
+      "matchManagers": [
+        "npm",
+        "docker",
+        "github-actions",
+        "helm",
+        "maven",
+        "gradle",
+        "pip",
+        "composer"
+      ],
       "enabled": true
     }
   ],

--- a/default.json
+++ b/default.json
@@ -183,7 +183,6 @@
       "currentValueTemplate": "github>bcgov/renovate-config",
       "autoReplaceStringTemplate": "\"github>{{packageName}}#v1\"",
       "datasourceTemplate": "github",
-      "versioningTemplate": "semver",
       "packageNameTemplate": "bcgov/renovate-config"
     }
   ]

--- a/default.json
+++ b/default.json
@@ -182,7 +182,6 @@
       "depNameTemplate": "renovate-v1-config",
       "currentValueTemplate": "github>bcgov/renovate-config",
       "autoReplaceStringTemplate": "\"github>{{packageName}}#v1\"",
-      "datasourceTemplate": "github",
       "packageNameTemplate": "bcgov/renovate-config"
     }
   ]

--- a/default.json
+++ b/default.json
@@ -182,7 +182,7 @@
       "depNameTemplate": "renovate-v1-config",
       "currentValueTemplate": "github>bcgov/renovate-config",
       "autoReplaceStringTemplate": "\"github>{{packageName}}#v1\"",
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github",
       "versioningTemplate": "semver",
       "packageNameTemplate": "bcgov/renovate-config"
     }


### PR DESCRIPTION
## What Changed

Changed the datasource for the regex manager from  to :

### Issue:
- Renovate was skipping the unversioned reference with 
- The  datasource doesn't handle unversioned references like  properly

### Fix:
- Changed  from  to 
-  datasource should better handle unversioned references

### Why This Should Work:
- The debug logs showed our regex manager is working correctly
- It's detecting the dependency and current value properly
- The issue appears to be datasource validation, not regex pattern matching
-  is more appropriate for repository references that don't specify versions

This should resolve the  issue and allow the v1 migration to proceed.