### PR TITLE
fix: adapt working regex manager pattern for renovate-config migration

### DIFF
--- a/default.json
+++ b/default.json
@@ -177,10 +177,9 @@
         "/.github/renovate.json5/"
       ],
       "matchStrings": [
-        "\"github>bcgov/renovate-config\""
+        "\"(?<currentValue>github>bcgov/renovate-config)\""
       ],
       "depNameTemplate": "renovate-v1-config",
-      "currentValueTemplate": "github>bcgov/renovate-config",
       "autoReplaceStringTemplate": "\"github>{{packageName}}#v1\"",
       "datasourceTemplate": "github",
       "packageNameTemplate": "bcgov/renovate-config"

--- a/default.json
+++ b/default.json
@@ -163,16 +163,6 @@
       ],
       "matchCurrentVersion": "/^v?\\d+\\.\\d+\\.\\d+$/",
       "allowedVersions": "/^v?\\d+\\.\\d+\\.\\d+$/",
-      "matchManagers": [
-        "npm",
-        "docker",
-        "github-actions",
-        "helm",
-        "maven",
-        "gradle",
-        "pip",
-        "composer"
-      ],
       "enabled": true
     }
   ],

--- a/default.json
+++ b/default.json
@@ -193,6 +193,7 @@
       "currentValueTemplate": "github>bcgov/renovate-config",
       "autoReplaceStringTemplate": "\"github>{{packageName}}#v1\"",
       "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver",
       "packageNameTemplate": "bcgov/renovate-config"
     }
   ]

--- a/default.json
+++ b/default.json
@@ -181,7 +181,7 @@
       ],
       "depNameTemplate": "renovate-v1-config",
       "autoReplaceStringTemplate": "\"github>{{packageName}}#v1\"",
-      "datasourceTemplate": "github",
+      "datasourceTemplate": "github-tags",
       "packageNameTemplate": "bcgov/renovate-config"
     }
   ]

--- a/default.json
+++ b/default.json
@@ -182,6 +182,7 @@
       "depNameTemplate": "renovate-v1-config",
       "currentValueTemplate": "github>bcgov/renovate-config",
       "autoReplaceStringTemplate": "\"github>{{packageName}}#v1\"",
+      "datasourceTemplate": "github",
       "packageNameTemplate": "bcgov/renovate-config"
     }
   ]

--- a/default.json
+++ b/default.json
@@ -182,7 +182,7 @@
       "depNameTemplate": "renovate-v1-config",
       "currentValueTemplate": "github>bcgov/renovate-config",
       "autoReplaceStringTemplate": "\"github>{{packageName}}#v1\"",
-      "datasourceTemplate": "github-releases",
+      "datasourceTemplate": "github-tags",
       "packageNameTemplate": "bcgov/renovate-config"
     }
   ]

--- a/default.json
+++ b/default.json
@@ -163,6 +163,16 @@
       ],
       "matchCurrentVersion": "/^v?\\d+\\.\\d+\\.\\d+$/",
       "allowedVersions": "/^v?\\d+\\.\\d+\\.\\d+$/",
+      "matchManagers": [
+        "npm",
+        "docker",
+        "github-actions",
+        "helm",
+        "maven",
+        "gradle",
+        "pip",
+        "composer"
+      ],
       "enabled": true
     }
   ],

--- a/default.json
+++ b/default.json
@@ -183,7 +183,6 @@
       "currentValueTemplate": "github>bcgov/renovate-config",
       "autoReplaceStringTemplate": "\"github>{{packageName}}#v1\"",
       "datasourceTemplate": "github",
-      "versioningTemplate": "semver",
       "packageNameTemplate": "bcgov/renovate-config"
     }
   ]

--- a/default.json
+++ b/default.json
@@ -182,7 +182,6 @@
       "depNameTemplate": "renovate-v1-config",
       "currentValueTemplate": "github>bcgov/renovate-config",
       "autoReplaceStringTemplate": "\"github>{{packageName}}#v1\"",
-      "datasourceTemplate": "github",
       "packageNameTemplate": "bcgov/renovate-config"
     }
   ]

--- a/default.json
+++ b/default.json
@@ -182,7 +182,7 @@
       "depNameTemplate": "renovate-v1-config",
       "currentValueTemplate": "github>bcgov/renovate-config",
       "autoReplaceStringTemplate": "\"github>{{packageName}}#v1\"",
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github",
       "versioningTemplate": "semver",
       "packageNameTemplate": "bcgov/renovate-config"
     }


### PR DESCRIPTION
## Summary

This PR adapts the proven working Yarn regex manager pattern to handle the migration of unversioned renovate-config references to v1.

## Changes

- Use capture group  pattern from working examples instead of 
- Adapt the exact structure used in the Yarn example: , , , 
- Target unversioned  references
- Replace with  using templating variables

## Technical Details

The configuration follows the exact pattern from the working Yarn example:
- **Capture group extraction**: 
- **Template-based replacement**: 
- **Required datasource**:  (for tag-based references)

This approach is more reliable than previous attempts as it follows proven working patterns rather than experimental configurations.