### PR TITLE
feat: enable preset version updates using built-in manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -94,6 +94,17 @@
       "enabled": false
     },
     {
+      "description": "Enable preset version updates to v1 family: Allow bcgov/renovate-config updates to v1, v1.0, or v1.0.0 versions",
+      "matchManagers": [
+        "renovate-config-presets"
+      ],
+      "matchPackageNames": [
+        "github>bcgov/renovate-config"
+      ],
+      "allowedVersions": "/^v1(\\.0)?(\\.0)?$/",
+      "enabled": true
+    },
+    {
       "description": "Block prerelease updates globally: Prevent updates to alpha, beta, rc, next, preview, dev, experimental versions across all package managers. These are unstable and should be avoided in production.",
       "matchCurrentVersion": "/.*-(alpha|beta|rc|next|preview|dev|experimental).*/",
       "matchManagers": []
@@ -156,27 +167,5 @@
       "groupName": "python dependencies",
       "groupSlug": "python"
     }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Temporary: Migrate unversioned renovate-config references to v1",
-      "managerFilePatterns": [
-        "/renovate\\.json$/"
-      ],
-      "matchStrings": [
-        "\"(?<currentValue>github>bcgov/renovate-config)\""
-      ],
-      "datasourceTemplate": "custom.v1-migration",
-      "depNameTemplate": "bcgov/renovate-config"
-    }
-  ],
-  "customDatasources": {
-    "v1-migration": {
-      "defaultRegistryUrlTemplate": "https://api.github.com/repos/bcgov/renovate-config/releases",
-      "transformTemplates": [
-        "{ \"releases\": [{ \"version\": \"v1\", \"releaseTimestamp\": \"2025-08-27T00:00:00Z\" }] }"
-      ]
-    }
-  }
+  ]
 }


### PR DESCRIPTION
## Summary

Replaces custom manager approach with Renovate's built-in preset manager for automated v1 migration.

## Changes

- **Removed custom managers**: Eliminates complex custom regex managers and datasources
- **Added packageRule**: Enables version updates for `bcgov/renovate-config` presets using built-in `renovate-config-presets` manager
- **Version constraints**: Restricts updates to v1 family only (`v1`, `v1.0`, `v1.0.0`) using `allowedVersions`
- **Preserved digest blocking**: Keeps existing rule to prevent digest/SHA pinning

## Technical Approach

Uses Renovate's native preset handling instead of custom regex managers:
- Built-in `renovate-config-presets` manager automatically detects preset references
- `allowedVersions: "/^v1(\\.0)?(\\.0)?$/"` constrains to v1 family
- Works with real git tags from the repository
- Leverages proven Renovate functionality

## Benefits

- **Simpler configuration**: No complex custom managers or fake datasources
- **More reliable**: Uses established Renovate patterns
- **Real version data**: Works with actual git tags instead of synthetic data
- **Better maintainability**: Follows standard Renovate practices

## Testing

- Configuration validates successfully
- Targets `renovate-config-presets` manager specifically
- Should automatically migrate unversioned `github>bcgov/renovate-config` to `github>bcgov/renovate-config#v1`

This approach leverages Renovate's built-in capabilities rather than working around them.