### PR TITLE
chore: remove ineffective container unpinning rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 **Dependency updates are a leading cause of security incidents, outages, and technical debt.** Renovate automates this critical maintenance task, saving your team time and reducing risk.
 
 **What you get with this shared configuration:**
-- **Security:** Global pinning to SHAs/digests for supply chain security
+- **Security:** Selective pinning to SHAs/digests for package managers (npm, pip, maven, etc.)
 - **Efficiency:** Grouped PRs by ecosystem (JS/TS, Python, Java, Actions, Docker, etc.)
 - **Safety:** Automerge for safe updates (minor, patch, linters, etc.)
 - **Stability:** Prerelease blocking (e.g., `-alpha`, `-beta`, `-rc`, etc.)

--- a/default.json
+++ b/default.json
@@ -68,25 +68,6 @@
       "pinDigests": true
     },
     {
-      "description": "Unpin Docker containers: Prevent SHA digest pinning for Docker images. Container registries provide their own security guarantees through signed tags.",
-      "matchManagers": [
-        "dockerfile",
-        "docker-compose",
-        "kubernetes"
-      ],
-      "pinDigests": false
-    },
-    {
-      "description": "Unpin GitHub Actions services: Prevent SHA digest pinning for service containers in GitHub Actions workflows.",
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchDepTypes": [
-        "service"
-      ],
-      "pinDigests": false
-    },
-    {
       "description": "Prevent config preset pinning: Stop Renovate from trying to pin bcgov/renovate-config as a dependency. Config presets are references, not dependencies that need pinning.",
       "matchPackageNames": [
         "github>bcgov/renovate-config"

--- a/default.json
+++ b/default.json
@@ -67,7 +67,25 @@
       ],
       "pinDigests": true
     },
-
+    {
+      "description": "Unpin Docker containers: Prevent SHA digest pinning for Docker images. Container registries provide their own security guarantees through signed tags.",
+      "matchManagers": [
+        "dockerfile",
+        "docker-compose",
+        "kubernetes"
+      ],
+      "pinDigests": false
+    },
+    {
+      "description": "Unpin GitHub Actions services: Prevent SHA digest pinning for service containers in GitHub Actions workflows.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchDepTypes": [
+        "service"
+      ],
+      "pinDigests": false
+    },
     {
       "description": "Prevent config preset pinning: Stop Renovate from trying to pin bcgov/renovate-config as a dependency. Config presets are references, not dependencies that need pinning.",
       "matchPackageNames": [

--- a/default.json
+++ b/default.json
@@ -67,22 +67,7 @@
       ],
       "pinDigests": true
     },
-    {
-      "description": "Unpin containers: Docker images are handled by image tags rather than digests. Container registries provide their own security guarantees through signed tags.",
-      "matchManagers": [
-        "dockerfile",
-        "docker-compose",
-        "kubernetes"
-      ],
-      "pinDigests": false
-    },
-    {
-      "description": "Unpin service containers: Service containers (like postgres, redis, etc.) are handled by image tags rather than digests. These are runtime dependencies that should use stable tags.",
-      "matchDepTypes": [
-        "service"
-      ],
-      "pinDigests": false
-    },
+
     {
       "description": "Prevent config preset pinning: Stop Renovate from trying to pin bcgov/renovate-config as a dependency. Config presets are references, not dependencies that need pinning.",
       "matchPackageNames": [


### PR DESCRIPTION
Removes container unpinning rules that only prevented new SHA pins but didn't remove existing ones. Since prevention is working well, this simplifies the configuration without changing effective behavior.