### PR TITLE
refactor: reorganize ecosystem rules for consistency

### DIFF
--- a/default.json
+++ b/default.json
@@ -27,6 +27,7 @@
     ":semanticCommits",
     ":semanticCommitScope(deps)",
     "github>bcgov/renovate-config:rules-actions.json5",
+    "github>bcgov/renovate-config:rules-infrastructure.json5",
     "github>bcgov/renovate-config:rules-java.json5",
     "github>bcgov/renovate-config:rules-javascript.json5",
     "github>bcgov/renovate-config:rules-python.json5"
@@ -81,64 +82,6 @@
       "description": "Block prerelease updates globally: Prevent updates to alpha, beta, rc, next, preview, dev, experimental versions across all package managers. These are unstable and should be avoided in production.",
       "matchCurrentVersion": "/.*-(alpha|beta|rc|next|preview|dev|experimental).*/",
       "matchManagers": []
-    },
-    {
-      "description": "Group infrastructure providers: Combine Terraform, Docker, Kubernetes, Helm, and Docker Compose updates into single PRs. Infrastructure changes should be reviewed together for consistency.",
-      "matchManagers": [
-        "terraform",
-        "dockerfile",
-        "kubernetes",
-        "helmv3",
-        "docker-compose"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "infrastructure updates",
-      "groupSlug": "infra"
-    },
-    {
-      "description": "Group Node.js ecosystem: Combine npm, yarn, and pnpm updates into single PRs. JavaScript/TypeScript dependencies should be updated together to maintain compatibility.",
-      "matchManagers": [
-        "npm",
-        "yarn",
-        "pnpm"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "node dependencies",
-      "groupSlug": "node"
-    },
-    {
-      "description": "Group Java ecosystem: Combine Maven and Gradle updates into single PRs. Java dependencies should be updated together to maintain compatibility and avoid version conflicts.",
-      "matchManagers": [
-        "maven",
-        "gradle"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "java dependencies",
-      "groupSlug": "java"
-    },
-    {
-      "description": "Group Python ecosystem: Combine pip, pipenv, poetry, and uv updates into single PRs. Python dependencies should be updated together to maintain compatibility and avoid conflicts.",
-      "matchManagers": [
-        "pip",
-        "pipenv",
-        "poetry",
-        "uv"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "python dependencies",
-      "groupSlug": "python"
     }
   ],
   "customManagers": [

--- a/rules-infrastructure.json5
+++ b/rules-infrastructure.json5
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  // Renovate packageRules for infrastructure dependencies (Terraform, Docker, Kubernetes, Helm).
+  // This file is intended to be referenced by downstream repositories for consistent update grouping.
+  "packageRules": [
+    // Group infrastructure providers: Combine Terraform, Docker, Kubernetes, Helm, and Docker Compose updates into single PRs
+    {
+      "description": "Group infrastructure providers: Combine Terraform, Docker, Kubernetes, Helm, and Docker Compose updates into single PRs. Infrastructure changes should be reviewed together for consistency.",
+      "matchManagers": [
+        "terraform",
+        "dockerfile",
+        "kubernetes",
+        "helmv3",
+        "docker-compose"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "infrastructure updates",
+      "groupSlug": "infra"
+    }
+    // Add additional infrastructure rules below as needed
+  ]
+}

--- a/rules-java.json5
+++ b/rules-java.json5
@@ -21,6 +21,20 @@
         "lockFileMaintenance"
       ],
       "minimumReleaseAge": "7 days"
+    },
+    // Group Java ecosystem: Combine Maven and Gradle updates into single PRs
+    {
+      "description": "Group Java ecosystem: Combine Maven and Gradle updates into single PRs. Java dependencies should be updated together to maintain compatibility and avoid version conflicts.",
+      "matchManagers": [
+        "maven",
+        "gradle"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "java dependencies",
+      "groupSlug": "java"
     }
     // Add more grouping rules as needed for your Java ecosystem
   ]

--- a/rules-javascript.json5
+++ b/rules-javascript.json5
@@ -69,6 +69,21 @@
       "groupName": "eslint9",
       "matchManagers": ["npm"],
       "matchPackageNames": ["/eslint/"]
+    },
+    // Group Node.js ecosystem: Combine npm, yarn, and pnpm updates into single PRs
+    {
+      "description": "Group Node.js ecosystem: Combine npm, yarn, and pnpm updates into single PRs. JavaScript/TypeScript dependencies should be updated together to maintain compatibility.",
+      "matchManagers": [
+        "npm",
+        "yarn",
+        "pnpm"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "node dependencies",
+      "groupSlug": "node"
     }
     // Add additional rules below as needed
   ]

--- a/rules-python.json5
+++ b/rules-python.json5
@@ -24,6 +24,22 @@
         "/^sqlacodegen$/",
         "/^mock-alchemy$/"
       ]
+    },
+    // Group Python ecosystem: Combine pip, pipenv, poetry, and uv updates into single PRs
+    {
+      "description": "Group Python ecosystem: Combine pip, pipenv, poetry, and uv updates into single PRs. Python dependencies should be updated together to maintain compatibility and avoid conflicts.",
+      "matchManagers": [
+        "pip",
+        "pipenv",
+        "poetry",
+        "uv"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "python dependencies",
+      "groupSlug": "python"
     }
   ]
 }


### PR DESCRIPTION
## Problem

The current structure was inconsistent - we had ecosystem-specific grouping rules in  mixed with global policies, while the  files were intended for ecosystem-specific rules.

## Solution

Move ecosystem-specific grouping rules from  to their appropriate  files:

- **Infrastructure rules** → new 
- **Node.js ecosystem rules** →   
- **Java ecosystem rules** → 
- **Python ecosystem rules** → 

## Structure After Changes

** now contains only:**
- Global pinning policy (applies to multiple ecosystems)
- Config preset prevention (meta-rule about the config itself)  
- Prerelease blocking (global policy)

** files contain:**
- Ecosystem-specific grouping rules
- Framework-specific rules (vite, angular, etc.)

## Benefits

✅ **Consistent structure** - ecosystem rules live in ecosystem files  
✅ **Easier maintenance** - find Node rules in   
✅ **Cleaner ** - only truly global policies  
✅ **Better extensibility** - add new ecosystems easily  

This follows the principle of keeping related configuration together and makes the codebase more maintainable.