### PR TITLE
fix: correct negative pattern syntax for pinning exclusions

### DIFF
--- a/rules-actions.json5
+++ b/rules-actions.json5
@@ -14,25 +14,14 @@
       ]
     },
     // Pin third-party GitHub Actions with SHA digests for supply chain security
-    // Excludes trusted orgs (actions/, docker/, github/) which are safe to use version tags
+    // Excludes trusted orgs (actions/, docker/, github/, etc.) which are safe to use version tags
     {
       "description": "Pin GitHub Actions with SHA digests (excludes trusted orgs)",
       "matchManagers": [
         "github-actions"
       ],
-      "matchPackageNames": [
-        "!^actions/",
-        "!^aquasecurity/",
-        "!^aws-actions/",
-        "!^azure/",
-        "!^codecov/",
-        "!^coverallsapp/",
-        "!^docker/",
-        "!^github/",
-        "!^google-github-actions/",
-        "!^hashicorp/",
-        "!^helm/",
-        "!^sonarsource/"
+      "matchPackagePatterns": [
+        "^(?!actions/|aquasecurity/|aws-actions/|azure/|codecov/|coverallsapp/|docker/|github/|google-github-actions/|hashicorp/|helm/|sonarsource/).*"
       ],
       "pinDigests": true
     }

--- a/rules-infrastructure.json5
+++ b/rules-infrastructure.json5
@@ -28,24 +28,8 @@
         "dockerfile",
         "docker-compose"
       ],
-      "matchPackageNames": [
-        "!^alpine$",
-        "!^amazonlinux$",
-        "!^caddy$",
-        "!^debian$",
-        "!^eclipse-temurin$",
-        "!^flyway$",
-        "!^gcr.io/distroless/",
-        "!^liquibase$",
-        "!^mongo$",
-        "!^nginx$",
-        "!^node$",
-        "!^openjdk$",
-        "!^postgres$",
-        "!^python$",
-        "!^redis$",
-        "!^sonarqube$",
-        "!^ubuntu$"
+      "matchPackagePatterns": [
+        "^(?!alpine$|amazonlinux$|caddy$|debian$|eclipse-temurin$|flyway$|gcr\\.io/distroless/|liquibase$|mongo$|nginx$|node$|openjdk$|postgres$|python$|redis$|sonarqube$|ubuntu$).*"
       ],
       "pinDigests": true
     }


### PR DESCRIPTION
## 🚨 Critical Security Fix

Fixes a security regression where trusted GitHub Actions and Docker images were incorrectly getting SHA-pinned despite being in our allowlists.

## Problem
The negative pattern syntax in `matchPackageNames` arrays wasn't working as expected:
```json5
"matchPackageNames": [
  "pushactions/",
  "pushdocker/"
],
"pinDigests": true
```

This caused `actions/checkout`, `actions/setup-node`, and other trusted packages to still get SHA-pinned.

## Solution
Replaced with `matchPackagePatterns` using proper negative lookahead regex:
```json5
"matchPackagePatterns": [
],
"pinDigests": true
```

## Impact
- ✅ Trusted orgs (actions/, docker/, etc.) now correctly use version tags
- ✅ Third-party packages still get SHA-pinned for security
- ✅ Fixes both GitHub Actions and Docker image pinning rules

## Evidence
See the incorrect pinning in action:
- https://github.com/bcgov/action-gh-project-automator/pull/75

This fix ensures our selective pinning strategy works as intended.