### PR TITLE
fix: simplify pinning logic to rely solely on negative pattern exclusions

### DIFF
--- a/rules-actions.json5
+++ b/rules-actions.json5
@@ -12,9 +12,9 @@
         "github-actions"
       ]
     },
-    // Pin third-party GitHub Actions with SHA digests for supply chain security
+    // Pin third-party GitHub Actions with SHA digests for supply chain security (excludes trusted orgs)
     {
-      "description": "Pin third-party GitHub Actions with SHA digests (excludes trusted orgs)",
+      "description": "Pin third-party GitHub Actions with SHA digests for supply chain security",
       "matchManagers": [
         "github-actions"
       ],
@@ -33,29 +33,6 @@
         "!^sonarsource/"
       ],
       "pinDigests": true
-    },
-    // Disable digest pinning for trusted GitHub Actions orgs (overrides above rule)
-    {
-      "description": "Disable digest pinning for trusted GitHub Actions orgs",
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchPackageNames": [
-        "^actions/",
-        "^aquasecurity/",
-        "^aws-actions/",
-        "^azure/",
-        "^codecov/",
-        "^coverallsapp/",
-        "^docker/",
-        "^github/",
-        "^google-github-actions/",
-        "^hashicorp/",
-        "^helm/",
-        "^sonarsource/"
-      ],
-      "matchUpdateTypes": ["pinDigest"],
-      "enabled": false
     }
     // Add additional rules below as needed
   ]

--- a/rules-infrastructure.json5
+++ b/rules-infrastructure.json5
@@ -20,36 +20,7 @@
       "groupName": "infrastructure updates",
       "groupSlug": "infra"
     },
-    // Disable digest pinning for trusted Docker base images
-    {
-      "description": "Disable digest pinning for trusted Docker base images",
-      "matchManagers": [
-        "dockerfile",
-        "docker-compose"
-      ],
-      "matchPackageNames": [
-        "^alpine$",
-        "^amazonlinux$",
-        "^caddy$",
-        "^debian$",
-        "^eclipse-temurin$",
-        "^flyway$",
-        "^gcr.io/distroless/",
-        "^liquibase$",
-        "^mongo$",
-        "^nginx$",
-        "^node$",
-        "^openjdk$",
-        "^postgres$",
-        "^python$",
-        "^redis$",
-        "^sonarqube$",
-        "^ubuntu$"
-      ],
-      "matchUpdateTypes": ["pinDigest"],
-      "enabled": false
-    },
-    // Pin all other Docker images for supply chain security
+    // Pin third-party Docker images for supply chain security (excludes trusted base images)
     {
       "description": "Pin third-party Docker images for supply chain security",
       "matchManagers": [


### PR DESCRIPTION
## 🔧 Simplify Pinning Logic After Previous Approach Failed

The three-rule cascade approach from the previous PR wasn't working - Renovate was still generating `pinDigest` updates for trusted GitHub Actions despite our `enabled: false` rules.

## Problem with Previous Approach
Even with this configuration:

Renovate logs still showed:


## New Simplified Approach
Remove complex override rules and rely **solely** on negative pattern exclusions:

**Before (complex):**
- Rule 1: Group all GitHub Actions
- Rule 2: Pin third-party actions (with negative patterns)  
- Rule 3: Disable pinDigest for trusted actions ← **This wasn't working**

**After (simple):**
- Rule 1: Group all GitHub Actions
- Rule 2: Pin third-party actions (with negative patterns) ← **Only rule that matters**

## Key Changes
- ✅ **Removed** the `enabled: false` rule that wasn't working
- ✅ **Simplified** to single pinning rule with negative exclusions
- ✅ **Maintained** unified GitHub Actions grouping
- ✅ **Preserved** allowlist of trusted orgs

## Expected Result
Trusted packages (`actions/*`, `docker/*`, etc.) should **never match** the `pinDigests: true` rule, preventing `pinDigest` updates from being generated at all.

## Files Changed
- `rules-actions.json5`: Removed complex override rule
- `rules-infrastructure.json5`: Removed complex override rule

This approach returns to the fundamentals: if a package doesn't match a rule, the rule doesn't apply to it.