### PR TITLE
test: migrate unversioned config references to v1

### DIFF
--- a/default.json
+++ b/default.json
@@ -174,5 +174,25 @@
       "allowedVersions": "/^v?\\d+\\.\\d+$/",
       "enabled": true
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Migrate unversioned renovate-config references to v1",
+      "managerFilePatterns": [
+        "/^renovate\\.json$/",
+        "/^\\.github/renovate\\.json$/",
+        "/^renovate\\.json5$/",
+        "/^\\.github/renovate\\.json5$/"
+      ],
+      "matchStrings": [
+        "\"github>bcgov/renovate-config\""
+      ],
+      "depNameTemplate": "github>bcgov/renovate-config",
+      "currentValueTemplate": "main",
+      "autoReplaceStringTemplate": "\"github>bcgov/renovate-config#v1\"",
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "bcgov/renovate-config"
+    }
   ]
 }


### PR DESCRIPTION
## Test Branch for Config Migration

This branch tests using  with  to migrate teams from unversioned renovate-config references to v1.

### Changes
- Added customManager with regex to detect unversioned renovate-config references
- Matches pattern: "github>bcgov/renovate-config" (without version)
- Replaces with: "github>bcgov/renovate-config#v1"
- Uses proper customManagers structure (not deprecated regexManagers)

### Testing
- Ready for testing with downstream repo that has unversioned config references
- If successful, this approach can be merged to main
- If unsuccessful, this branch can be abandoned

### Previous Attempts
- Multiple customManagers variations (failed)
- packageRules approach (may have been tried)
- Manual migration (not scalable)

This uses the current customManagers approach as documented in Renovate's official documentation.