### PR TITLE
fix: prevent v1 -> v1.1 updates to maintain version precision

### DIFF
--- a/default.json
+++ b/default.json
@@ -157,18 +157,7 @@
       "groupSlug": "python"
     },
     {
-      "description": "Block minor updates from single-digit versions: Prevent v1 -> v1.1 updates to maintain version precision",
-      "matchPackageNames": [
-        "github>bcgov/renovate-config"
-      ],
-      "matchCurrentVersion": "/^v?\\d+$/",
-      "matchUpdateTypes": [
-        "minor"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "Major-only updates for renovate-config: Teams using v1 format want only major version updates to minimize PR noise. Prevents minor updates that would create unnecessary maintenance burden.",
+      "description": "Single-digit version precision: Teams using v1 format want only major version updates (v1 -> v2). Prevents minor updates that would change precision (v1 -> v1.1).",
       "matchPackageNames": [
         "github>bcgov/renovate-config"
       ],
@@ -177,7 +166,7 @@
       "enabled": true
     },
     {
-      "description": "Minor+ updates and migration for renovate-config: Teams using v1.0 format get minor updates, while teams using v1.1.1 format are encouraged to migrate to v1.2 format for simpler config versioning. Balances stability with getting important config improvements.",
+      "description": "Multi-digit version precision: Teams using v1.0 or v1.1.1 format get minor updates, with three-digit versions migrating to two-digit (v1.1.1 -> v1.2).",
       "matchPackageNames": [
         "github>bcgov/renovate-config"
       ],

--- a/default.json
+++ b/default.json
@@ -173,6 +173,17 @@
       "matchCurrentVersion": "/^v?\\d+\\.\\d+(\\.\\d+)?$/",
       "allowedVersions": "/^v?\\d+\\.\\d+$/",
       "enabled": true
+    },
+    {
+      "description": "Block minor updates from single-digit versions: Prevent v1 -> v1.1 updates to maintain version precision",
+      "matchPackageNames": [
+        "github>bcgov/renovate-config"
+      ],
+      "matchCurrentVersion": "/^v?\\d+$/",
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -157,6 +157,17 @@
       "groupSlug": "python"
     },
     {
+      "description": "Block minor updates from single-digit versions: Prevent v1 -> v1.1 updates to maintain version precision",
+      "matchPackageNames": [
+        "github>bcgov/renovate-config"
+      ],
+      "matchCurrentVersion": "/^v?\\d+$/",
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Major-only updates for renovate-config: Teams using v1 format want only major version updates to minimize PR noise. Prevents minor updates that would create unnecessary maintenance burden.",
       "matchPackageNames": [
         "github>bcgov/renovate-config"

--- a/default.json
+++ b/default.json
@@ -173,17 +173,6 @@
       "matchCurrentVersion": "/^v?\\d+\\.\\d+(\\.\\d+)?$/",
       "allowedVersions": "/^v?\\d+\\.\\d+$/",
       "enabled": true
-    },
-    {
-      "description": "Block minor updates from single-digit versions: Prevent v1 -> v1.1 updates to maintain version precision",
-      "matchPackageNames": [
-        "github>bcgov/renovate-config"
-      ],
-      "matchCurrentVersion": "/^v?\\d+$/",
-      "matchUpdateTypes": [
-        "minor"
-      ],
-      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Problem
Renovate is incorrectly updating renovate-config references from `v1` to `v1.1`, violating the version precision rule we want to enforce. This creates unnecessary PR noise and maintenance burden.

## Solution
Added an explicit rule to block minor updates from single-digit versions while keeping the existing `allowedVersions` rules for comprehensive version precision enforcement.

## Changes
- Added rule to block minor updates from single-digit versions (e.g., v1 -> v1.1)
- Maintains existing rules for:
  - Single-digit to single-digit updates (v1 -> v2)
  - Two/three-digit to two-digit updates (v1.1.1 -> v1.2)

## Testing
- Configuration validates successfully with `renovate-config-validator`
- Rules are designed to prevent the specific issue shown in [PR #316](https://github.com/bcgov/renovate-config/pull/316/files)

This should prevent the unwanted v1 -> v1.1 updates while maintaining the desired versioning behavior for all other cases.