### PR TITLE
feat: attempted unversioned to v1 migration

### DIFF
--- a/default.json
+++ b/default.json
@@ -173,6 +173,25 @@
       "matchCurrentVersion": "/^v?\\d+\\.\\d+(\\.\\d+)?$/",
       "allowedVersions": "/^v?\\d+\\.\\d+$/",
       "enabled": true
+    },
+    {
+      "description": "Update unversioned renovate-config references to v1: Target repositories using the unversioned reference and update them to use the stable v1 tag, while ignoring repositories already using specific version tags.",
+      "matchFileNames": [
+        "renovate.json"
+      ],
+      "matchPackageNames": [
+        "github>bcgov/renovate-config"
+      ],
+      "matchCurrentVersion": "!/^v\\d+\\.\\d+(\\.\\d+)?$/",
+      "allowedVersions": "v1",
+      "enabled": true,
+      "automerge": false,
+      "commitMessageAction": "Update",
+      "commitMessageTopic": "bcgov renovate-config",
+      "commitMessageExtra": "to v1",
+      "prCreation": "not-pending",
+      "recreateWhen": "never",
+      "prBody": "## Update Renovate Config to v1\n\nThis PR updates your Renovate configuration from the unversioned reference to the stable v1 tag.\n\n### What Changes:\n- `github>bcgov/renovate-config` → `github>bcgov/renovate-config#v1`\n\n### Benefits:\n- ✅ **Stable updates** - get tested releases, not development changes\n- ✅ **Automatic upgrades** - get new v1.x.x releases automatically\n- ✅ **No breaking changes** - won't get v2+ breaking changes\n- ✅ **Easy rollback** - can pin to specific version if needed\n\nThis change is recommended for production stability. The v1 version receives regular updates and bug fixes while maintaining backward compatibility."
     }
   ]
 }


### PR DESCRIPTION
## Final Test: Unversioned → v1 Migration

This PR tests the packageRule-based migration approach found in commit 1e4d350 from the bk-main branch.

### What This Does:
- **Targets**: Repositories using unversioned  references
- **Updates**: Changes them to 
- **Excludes**: Repositories already using versioned references (v1, v1.0, v1.0.0, etc.)

### Key Differences from Previous Attempts:
- ✅ **Uses packageRule** instead of customManagers (more reliable)
- ✅ **Targets specific package** 
- ✅ **Uses negative regex** to exclude versioned references
- ✅ **Sets allowedVersions** to v1 (forces the target version)

### Testing Strategy:
1. **Point test repo** to this branch: 
2. **Use unversioned config** in test repo: 
3. **Run Renovate** and see if migration works with fresh cache
4. **If successful** → merge to main and update tags
5. **If unsuccessful** → FINALLY give up on migration

This is our last attempt. Previous failures may have been due to cache issues rather than the rule itself.