### PR TITLE
fix: prevent v1->v1.1 updates by restricting to major-only

### DIFF
--- a/default.json
+++ b/default.json
@@ -162,7 +162,7 @@
         "github>bcgov/renovate-config"
       ],
       "matchCurrentVersion": "/^v?\\d+$/",
-      "allowedVersions": "/^v?\\d+$/",
+      "matchUpdateTypes": ["major"],
       "enabled": true
     },
     {


### PR DESCRIPTION
## Problem
Renovate is still sending PRs updating config from v1 to v1.1, which violates our version precision policy. Teams using single-digit versions (v1) want only major updates (v1->v2), not minor updates that change precision.

## Solution
- Changed from `allowedVersions` to `matchUpdateTypes: ["major"]` for single-digit versions
- This explicitly blocks minor updates (v1->v1.1) while allowing major updates (v1->v2)
- More explicit than regex-based version filtering

## Testing
- Configuration validates successfully
- Should prevent unwanted precision-changing updates