### PR TITLE
fix: prevent allowlisted GitHub Actions from being pinned

### DIFF
--- a/rules-infra.json5
+++ b/rules-infra.json5
@@ -5,18 +5,24 @@
   "packageRules": [
     // ALLOWLISTED_ORGS: actions/, docker/, github/
     // These trusted orgs are grouped for easier maintenance
-    // Group all GitHub Actions together (default unpinned)
+    // Group allowlisted GitHub Actions (unpinned)
     {
-      "description": "Group all GitHub Actions together",
+      "description": "Group allowlisted GitHub Actions (unpinned)",
       "groupName": "github actions",
       "groupSlug": "github-actions",
       "matchManagers": [
         "github-actions"
-      ]
+      ],
+      "matchPackageNames": [
+        "^actions/",
+        "^docker/",
+        "^github/"
+      ],
+      "pinDigests": false
     },
-    // Pin non-allowlisted GitHub Actions (override default)
+    // Group and pin non-allowlisted GitHub Actions
     {
-      "description": "Pin non-allowlisted GitHub Actions for security",
+      "description": "Group and pin non-allowlisted GitHub Actions for security",
       "groupName": "github actions",
       "groupSlug": "github-actions",
       "matchManagers": [


### PR DESCRIPTION
## Critical Fix for GitHub Actions Pinning

This hotfix resolves an issue where allowlisted GitHub Actions (actions/, docker/, github/) were being incorrectly pinned.

### Problem
- Allowlisted actions like `actions/checkout`, `github/codeql-action` were being pinned
- Only non-allowlisted actions (like `bcgov/action-*`) should be pinned for security

### Solution
- **Explicit unpinning rule** for allowlisted orgs with `pinDigests: false`
- **Clear rule precedence** using positive matching instead of exclusion patterns
- **Separate rules** to avoid ambiguity between grouping and pinning logic

### Changes
- Split GitHub Actions rules into two explicit rules:
  1. Allowlisted orgs (actions/, docker/, github/) → unpinned
  2. Non-allowlisted orgs → pinned for security

This ensures trusted actions remain unpinned while maintaining security for custom actions.

### Testing
- Fixes the pinning issue observed in nr-spar dependency dashboard
- Maintains existing grouping behavior for all GitHub Actions

**Ready for immediate merge to stop unwanted pinning.**