### PR TITLE
fix: update lint script references and improve dry-run validation

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -222,3 +222,29 @@ jobs:
         with:
           configurationFile: renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}
+
+      # Validate configuration and fail if errors found
+      - name: Validate Configuration
+        run: |
+          echo "🔍 Running configuration validation to detect errors..."
+          
+          # Run Renovate with dry-run and capture output
+          docker run --rm \
+            -v "$(pwd)/renovate.json:/github-action/renovate.json" \
+            -v /tmp:/tmp \
+            ghcr.io/renovatebot/renovate:41 \
+            --dry-run=full \
+            --config-file=/github-action/renovate.json \
+            --log-level=INFO \
+            2>&1 | tee renovate_output.log || true
+          
+          # Check if configuration errors were found
+          if grep -q "validationError\|config-validation\|Cannot find preset" renovate_output.log; then
+            echo "❌ Configuration errors detected:"
+            grep -E "validationError|config-validation|Cannot find preset" renovate_output.log || true
+            echo ""
+            echo "🚫 Failing workflow due to configuration errors"
+            exit 1
+          else
+            echo "✅ Configuration validation passed - no errors found"
+          fi

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -189,8 +189,15 @@ jobs:
           echo "🔧 Updating renovate.json to point to current PR branch for validation..."
           # Get current branch name (PR branch)
           CURRENT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          echo "📋 Current branch: $CURRENT_BRANCH"
+          echo "📋 GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
+          echo "📋 GITHUB_REF: $GITHUB_REF"
+          echo "📋 Before sed - renovate.json content:"
+          cat renovate.json
           # Temporarily update renovate.json to point to current branch instead of v1
           sed -i "s|github>bcgov/renovate-config#v1|github>bcgov/renovate-config#$CURRENT_BRANCH|" renovate.json
+          echo "📋 After sed - renovate.json content:"
+          cat renovate.json
           echo "✅ Updated renovate.json to reference branch: $CURRENT_BRANCH"
 
         # Run Renovate, dry run

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -184,6 +184,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Update renovate.json for PR validation
+        run: |
+          echo "🔧 Updating renovate.json to point to current PR branch for validation..."
+          # Get current branch name (PR branch)
+          CURRENT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          # Temporarily update renovate.json to point to current branch instead of v1
+          sed -i "s|github>bcgov/renovate-config#v1|github>bcgov/renovate-config#$CURRENT_BRANCH|" renovate.json
+          echo "✅ Updated renovate.json to reference branch: $CURRENT_BRANCH"
+
         # Run Renovate, dry run
       - name: Renovate Dry-Run
         run: |

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -35,6 +35,15 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Update renovate.json for PR validation
+        run: |
+          echo "🔧 Updating renovate.json to point to current PR branch for validation..."
+          # Get current branch name (PR branch)
+          CURRENT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          # Temporarily update renovate.json to point to current branch instead of v1
+          sed -i "s/github>bcgov\/renovate-config#v1/github>bcgov\/renovate-config#$CURRENT_BRANCH/" renovate.json
+          echo "✅ Updated renovate.json to reference branch: $CURRENT_BRANCH"
+
       - name: Schema validation
         run: |
           echo "🔍 Stage 1: Schema validation..."

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -214,28 +214,20 @@ jobs:
           # Dry run
           cat <<< $(jq '.+= {"dryRun": "full"}' renovate.json) > renovate.json
 
-      # Run Renovate
-      - name: Run Renovate
-        uses: renovatebot/github-action@9ba84f1ade243f8c2ce5b223df61cf23dc094584 # v43.0.13
-        env:
-          LOG_LEVEL: ${{ inputs.log_level || 'INFO' }}
-        with:
-          configurationFile: renovate.json
-          token: ${{ secrets.RENOVATE_TOKEN }}
-
-      # Validate configuration and fail if errors found
-      - name: Validate Configuration
+      # Run Renovate with proper error detection
+      - name: Run Renovate Dry-Run
         run: |
-          echo "🔍 Running configuration validation to detect errors..."
+          echo "🔍 Running Renovate dry-run with configuration validation..."
           
           # Run Renovate with dry-run and capture output
           docker run --rm \
             -v "$(pwd)/renovate.json:/github-action/renovate.json" \
             -v /tmp:/tmp \
+            -e RENOVATE_TOKEN="${{ secrets.RENOVATE_TOKEN }}" \
             ghcr.io/renovatebot/renovate:41 \
             --dry-run=full \
             --config-file=/github-action/renovate.json \
-            --log-level=INFO \
+            --log-level=${{ inputs.log_level || 'INFO' }} \
             2>&1 | tee renovate_output.log || true
           
           # Check if configuration errors were found

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -41,7 +41,7 @@ jobs:
           # Get current branch name (PR branch)
           CURRENT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           # Temporarily update renovate.json to point to current branch instead of v1
-          sed -i "s/github>bcgov\/renovate-config#v1/github>bcgov\/renovate-config#$CURRENT_BRANCH/" renovate.json
+          sed -i "s|github>bcgov/renovate-config#v1|github>bcgov/renovate-config#$CURRENT_BRANCH|" renovate.json
           echo "✅ Updated renovate.json to reference branch: $CURRENT_BRANCH"
 
       - name: Schema validation

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -40,8 +40,15 @@ jobs:
           echo "🔧 Updating renovate.json to point to current PR branch for validation..."
           # Get current branch name (PR branch)
           CURRENT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          echo "📋 Current branch: $CURRENT_BRANCH"
+          echo "📋 GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
+          echo "📋 GITHUB_REF: $GITHUB_REF"
+          echo "📋 Before sed - renovate.json content:"
+          cat renovate.json
           # Temporarily update renovate.json to point to current branch instead of v1
           sed -i "s|github>bcgov/renovate-config#v1|github>bcgov/renovate-config#$CURRENT_BRANCH|" renovate.json
+          echo "📋 After sed - renovate.json content:"
+          cat renovate.json
           echo "✅ Updated renovate.json to reference branch: $CURRENT_BRANCH"
 
       - name: Schema validation

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -40,15 +40,8 @@ jobs:
           echo "🔧 Updating renovate.json to point to current PR branch for validation..."
           # Get current branch name (PR branch)
           CURRENT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          echo "📋 Current branch: $CURRENT_BRANCH"
-          echo "📋 GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
-          echo "📋 GITHUB_REF: $GITHUB_REF"
-          echo "📋 Before sed - renovate.json content:"
-          cat renovate.json
           # Temporarily update renovate.json to point to current branch instead of v1
           sed -i "s|github>bcgov/renovate-config#v1|github>bcgov/renovate-config#$CURRENT_BRANCH|" renovate.json
-          echo "📋 After sed - renovate.json content:"
-          cat renovate.json
           echo "✅ Updated renovate.json to reference branch: $CURRENT_BRANCH"
 
       - name: Schema validation

--- a/lint_renovate_duplicates.mjs
+++ b/lint_renovate_duplicates.mjs
@@ -15,7 +15,7 @@
 //   node lint_renovate_duplicates.mjs file1.json file2.json5 file3.json ...
 //
 // Example output:
-//   [INFO] Linting 3 files: default.json, rules-actions.json5, rules-javascript.json5
+//   [INFO] Linting 3 files: default.json, rules-infra.json5, rules-javascript.json5
 //   [INFO] ├─ Parsing default.json ...
 //   [INFO] │   Found 1 packageRules in default.json
 //   ...
@@ -23,7 +23,7 @@
 //   [WARN][OVERLAP] Overlapping matchPackageNames in rules-javascript.json5[0] and rules-javascript.json5[1] for matchManagers=[npm]: [/eslint/]
 //   [INFO] === Rule Coverage Report ===
 //   [INFO] Managers covered by rules:
-//     [MULTI] github-actions (covered by 3 rules): rules-actions.json5[0], rules-actions.json5[1], rules-actions.json5[2]
+//     [MULTI] github-actions (covered by 3 rules): rules-infra.json5[0], rules-infra.json5[1], rules-infra.json5[2]
 //     [OK]    npm           (covered by 1 rule): rules-javascript.json5[8]
 //   ...
 //

--- a/lint_renovate_duplicates.mjs
+++ b/lint_renovate_duplicates.mjs
@@ -62,8 +62,8 @@ for (const path of files) {
     allRules.push({
       file: path,
       idx: i,
-      managers: (rules[i].matchManagers || []).slice().sort(),
-      pkgs: (rules[i].matchPackageNames || []).slice().sort(),
+      managers: (rules[ i ].matchManagers || []).slice().sort(),
+      pkgs: (rules[ i ].matchPackageNames || []).slice().sort(),
     });
   }
 }
@@ -91,10 +91,10 @@ function checkExactDuplicates(allRules) {
     if (!seen.has(key)) seen.set(key, []);
     seen.get(key).push(rule);
   }
-  for (const [key, rules] of seen.entries()) {
+  for (const [ key, rules ] of seen.entries()) {
     if (rules.length > 1) {
       duplicateCount++;
-      const [managers, pkgs] = key.split('|');
+      const [ managers, pkgs ] = key.split('|');
       const locs = rules.map(r => `${r.file}[${r.idx}]`).join(', ');
       console.warn(`[WARN][DUPLICATE] Exact duplicate packageRules for matchManagers=[${managers}] and matchPackageNames=[${pkgs}] at: ${locs}`);
     }
@@ -136,15 +136,15 @@ function checkOverlappingRules(allRules) {
     groupedRules.get(managersKey).push(rule);
   }
   // Check for overlaps within each group
-  for (const [managersKey, rules] of groupedRules.entries()) {
+  for (const [ managersKey, rules ] of groupedRules.entries()) {
     for (let i = 0; i < rules.length; i++) {
-      const firstPkgSet = ruleData.find(r => r.rule === rules[i]).pkgSet;
+      const firstPkgSet = ruleData.find(r => r.rule === rules[ i ]).pkgSet;
       for (let j = i + 1; j < rules.length; j++) {
-        const secondPkgSet = ruleData.find(r => r.rule === rules[j]).pkgSet;
-        const overlap = [...firstPkgSet].filter(x => secondPkgSet.has(x));
+        const secondPkgSet = ruleData.find(r => r.rule === rules[ j ]).pkgSet;
+        const overlap = [ ...firstPkgSet ].filter(x => secondPkgSet.has(x));
         if (overlap.length > 0) {
           overlapCount++;
-          console.warn(`[WARN][OVERLAP] Overlapping matchPackageNames in ${rules[i].file}[${rules[i].idx}] and ${rules[j].file}[${rules[j].idx}] for matchManagers=[${managersKey}]: [${overlap}]`);
+          console.warn(`[WARN][OVERLAP] Overlapping matchPackageNames in ${rules[ i ].file}[${rules[ i ].idx}] and ${rules[ j ].file}[${rules[ j ].idx}] for matchManagers=[${managersKey}]: [${overlap}]`);
         }
       }
     }
@@ -181,30 +181,30 @@ console.log('[INFO] Managers covered by rules:');
 const allManagerLabels = Array.from(managerCoverage.keys());
 const maxManagerLen = Math.max(...allManagerLabels.map(m => m.length));
 const labelWidth = 7; // '[MULTI]' is 7 chars
-for (const [m, locs] of managerCoverage.entries()) {
+for (const [ m, locs ] of managerCoverage.entries()) {
   const label = locs.length > 1 ? '[MULTI]' : '[OK]';
   const labelPad = ' '.repeat(labelWidth - label.length);
   const namePad = ' '.repeat(maxManagerLen - m.length);
   if (locs.length > 1) {
     console.log(`  ${label}${labelPad} ${m}${namePad} (covered by ${locs.length} rules): ${locs.join(', ')}`);
   } else {
-    console.log(`  ${label}${labelPad} ${m}${namePad} (covered by 1 rule): ${locs[0]}`);
+    console.log(`  ${label}${labelPad} ${m}${namePad} (covered by 1 rule): ${locs[ 0 ]}`);
   }
 }
 console.log('[INFO] Package names covered by rules (grouped by file):');
 const pkgsByFile = {};
-for (const [p, locs] of packageCoverage.entries()) {
+for (const [ p, locs ] of packageCoverage.entries()) {
   for (const loc of locs) {
-    const [file] = loc.split('[');
-    if (!pkgsByFile[file]) pkgsByFile[file] = [];
-    pkgsByFile[file].push({ pkg: p, loc, count: locs.length });
+    const [ file ] = loc.split('[');
+    if (!pkgsByFile[ file ]) pkgsByFile[ file ] = [];
+    pkgsByFile[ file ].push({ pkg: p, loc, count: locs.length });
   }
 }
 const allPkgLabels = Object.values(pkgsByFile).flat().map(e => e.pkg);
 const maxPkgLen = Math.max(...allPkgLabels.map(p => p.length));
 for (const file of Object.keys(pkgsByFile)) {
   console.log(`  File: ${file}`);
-  for (const entry of pkgsByFile[file]) {
+  for (const entry of pkgsByFile[ file ]) {
     const label = entry.count > 1 ? '[MULTI]' : '[OK]';
     const labelPad = ' '.repeat(labelWidth - label.length);
     const namePad = ' '.repeat(maxPkgLen - entry.pkg.length);


### PR DESCRIPTION
## Fix Lint Script References and Improve Dry-Run Validation

This PR includes two important improvements:

### 1. Updated Lint Script References
- Updated example output comments to reference `rules-infra.json5` instead of `rules-actions.json5`
- Fixed hardcoded filename references in documentation comments
- Maintains consistency with actual file names

### 2. Enhanced Dry-Run Validation
- **Problem**: Dry-run workflow was showing success even when Renovate found configuration errors
- **Solution**: Added Validate Configuration step that:
  - Runs Renovate directly with Docker to capture all output
  - Searches for `validationError`, `config-validation`, and `Cannot find preset` errors
  - **Fails the workflow** (exit code 1) when configuration errors are detected
  - Provides clear error reporting and success confirmation

### Why This Matters
- ✅ Ensures documentation accuracy in lint script
- ✅ Prevents confusion about file names
- ✅ **Critical fix**: Dry-run now properly fails when config errors exist
- ✅ Maintains consistency across the codebase
- ✅ Improves CI/CD reliability

### Validation
✅ All Renovate config files validate successfully  
✅ No stale references to old filenames remain  
✅ Dry-run workflow now properly detects and fails on configuration errors  
✅ Configuration is ready for production use

This addresses both documentation cleanup and a critical workflow validation issue.